### PR TITLE
fix: MCCC saved card feature (checkbox honored, correct gateway_id, delete guard)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,6 +135,8 @@ WooCommerce High Performance Order Storage（HPOS）完全対応済み。
 - **外部スクリプトURLは `https://` を明示**（プロトコル相対 `//` は禁止。httpサイトでは
   ポート80へ解決され、Paygent側が遮断するためページ描画が約75秒ブロックされる）
 - `phpcs` / `phpstan` が設定されている場合はコミット前に実行
+- **git commit / push はユーザーからの明示的な指示があるまで実行しない**。
+  修正はワーキングツリーに残した状態で報告し、コミットするかどうかの判断はユーザーに委ねる
 
 ## Claude Code スキル
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1562,7 +1562,8 @@ jQuery(function(){
 	 */
 	public function validate_fields() {
 		// Check for saving payment info without having or creating an account.
-		if ( $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
+		// Strict comparison: the Block checkout sends 'no' when the box is unchecked.
+		if ( 'yes' === $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
 		&& ! is_user_logged_in()
 		&& ! $this->jp4wc_framework->get_post( 'createaccount' ) ) {
 			wc_add_notice( __( 'Sorry, you need to create an account in order for us to save your payment information.', 'woocommerce-for-paygent-payment-main' ), $notice_type = 'error' );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1089,14 +1089,15 @@ jQuery(function(){
 	/**
 	 * Add stored card information for 3D Secure 2.0
 	 *
-	 * @param string $user_id    User ID to store the card for.
-	 * @param string $card_token Token representing the card to store.
-	 * @param object $order      Order object.
+	 * @param string $user_id          User ID to store the card for.
+	 * @param string $card_token       Token representing the card to store.
+	 * @param object $order            Order object.
+	 * @param string $token_gateway_id Gateway ID to save the WC token under (defaults to $this->id).
 	 * @return mixed Result from add_stored_user_data call
 	 */
-	public function paygent_tds_add_stored_card( $user_id, $card_token, $order ) {
+	public function paygent_tds_add_stored_card( $user_id, $card_token, $order, $token_gateway_id = null ) {
 		$card_user_id = 'wc' . $user_id;
-		$result       = $this->add_stored_user_data( $card_user_id, $card_token, $this->test_mode, $this->debug, $order );
+		$result       = $this->add_stored_user_data( $card_user_id, $card_token, $this->test_mode, $this->debug, $order, $token_gateway_id );
 		return $result;
 	}
 
@@ -1493,9 +1494,10 @@ jQuery(function(){
 	 * @param bool   $test_mode    Test mode.
 	 * @param bool   $debug        Debug mode.
 	 * @param object $order WC_Order.
+	 * @param string $token_gateway_id Gateway ID to save the WC token under (defaults to $this->id).
 	 * @return mixed
 	 */
-	public function add_stored_user_data( $user_id, $card_token, $test_mode, $debug, $order = null ) {
+	public function add_stored_user_data( $user_id, $card_token, $test_mode, $debug, $order = null, $token_gateway_id = null ) {
 		$telegram_kind = '025';
 		$send_data     = array(
 			'trading_id'      => '',
@@ -1539,7 +1541,7 @@ jQuery(function(){
 			$token = new WC_Payment_Token_CC();
 			$token->set_default( true );
 			$token->set_token( $card_token );
-			$token->set_gateway_id( $this->id );
+			$token->set_gateway_id( $token_gateway_id ?? $this->id );
 			$token->set_last4( $card_last4 );
 			$token->set_card_type( $card_type );
 			$token->set_expiry_month( $expiry_month );
@@ -1560,7 +1562,7 @@ jQuery(function(){
 	 */
 	public function validate_fields() {
 		// Check for saving payment info without having or creating an account.
-		if ( $this->jp4wc_framework->get_post( 'saveinfo' )
+		if ( $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
 		&& ! is_user_logged_in()
 		&& ! $this->jp4wc_framework->get_post( 'createaccount' ) ) {
 			wc_add_notice( __( 'Sorry, you need to create an account in order for us to save your payment information.', 'woocommerce-for-paygent-payment-main' ), $notice_type = 'error' );
@@ -2013,6 +2015,9 @@ jQuery(function(){
 	 * @return void
 	 */
 	public function paygent_delete_card( $token_id, $token ) {
+		if ( $token->get_gateway_id() !== $this->id ) {
+			return;
+		}
 		$customer_card_id = $token->get_meta( 'customer_card_id' );
 		$delete_card_data = array(
 			'customer_id'      => 'wc' . get_current_user_id(),

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -501,7 +501,7 @@ class WC_Gateway_Paygent_CC extends WC_Payment_Gateway {
 		if ( 'yes' === $this->store_card_info && is_user_logged_in() && ! $is_subscription ) {
 			echo '<p class="form-row form-row-wide">';
 			echo '<label for="paygent_save_card_info">';
-			echo '<input type="checkbox" id="paygent_save_card_info" name="paygent_save_card_info" value="yes" style="width:auto;margin-right:6px;">';
+			echo '<input type="checkbox" id="paygent_save_card_info" name="paygent_cc_save_card_info" value="yes" style="width:auto;margin-right:6px;">';
 			echo esc_html__( 'Save payment information to my account for future purchases.', 'woocommerce-for-paygent-payment-main' );
 			echo '</label>';
 			echo '</p>';
@@ -739,7 +739,11 @@ jQuery(function(){
 		}
 
 		// Save user's card-save preference to meta (needed for 3DS2 callback which has no POST data).
-		$user_wants_save_card = ( true === $subscription ) || ( 'yes' === sanitize_text_field( wp_unslash( $_POST['paygent_save_card_info'] ?? '' ) ) );// phpcs:ignore
+		// The gateway-specific key from the classic checkbox wins; the shared key is the
+		// Blocks fallback. Hidden checkboxes of other gateways still submit on classic
+		// checkout, so the shared key alone would leak their state into this gateway.
+		$save_card_post       = $_POST['paygent_cc_save_card_info'] ?? $_POST['paygent_save_card_info'] ?? '';// phpcs:ignore
+		$user_wants_save_card = ( true === $subscription ) || ( 'yes' === sanitize_text_field( wp_unslash( $save_card_post ) ) );
 		$order->update_meta_data( '_paygent_save_card_preference', $user_wants_save_card ? '1' : '0' );
 		$order->save_meta_data();
 
@@ -1565,7 +1569,9 @@ jQuery(function(){
 	public function validate_fields() {
 		// Check for saving payment info without having or creating an account.
 		// Strict comparison: the Block checkout sends 'no' when the box is unchecked.
-		if ( 'yes' === $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
+		// Classic checkout posts the gateway-specific key, Blocks the shared one.
+		if ( ( 'yes' === $this->jp4wc_framework->get_post( 'paygent_cc_save_card_info' )
+			|| 'yes' === $this->jp4wc_framework->get_post( 'paygent_save_card_info' ) )
 		&& ! is_user_logged_in()
 		&& ! $this->jp4wc_framework->get_post( 'createaccount' ) ) {
 			wc_add_notice( __( 'Sorry, you need to create an account in order for us to save your payment information.', 'woocommerce-for-paygent-payment-main' ), $notice_type = 'error' );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1862,9 +1862,10 @@ jQuery(function(){
 	/**
 	 * Read Paygent Token javascript
 	 *
-	 * @param array $delete_card_data Delete Card Data.
+	 * @param array  $delete_card_data Delete Card Data.
+	 * @param string $token_gateway_id Gateway ID whose remaining tokens get a new default (defaults to $this->id).
 	 */
-	public function delete_card( $delete_card_data ) {
+	public function delete_card( $delete_card_data, $token_gateway_id = null ) {
 		$telegram_kind = '026';
 		$order         = null;
 
@@ -1877,7 +1878,7 @@ jQuery(function(){
 		$delete_card_res = $this->paygent_request->send_paygent_request( $this->test_mode, $order, $telegram_kind, $delete_card_data, $this->debug );
 		if ( '0' === $delete_card_res['result'] ) {
 			// Set the remaining card as the default.
-			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id(), $this->id );
+			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id(), $token_gateway_id ?? $this->id );
 			if ( ! empty( $tokens ) ) {
 				$default_token = reset( $tokens );
 				$default_token->set_default( true );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1866,8 +1866,9 @@ jQuery(function(){
 	 *
 	 * @param array  $delete_card_data Delete Card Data.
 	 * @param string $token_gateway_id Gateway ID whose remaining tokens get a new default (defaults to $this->id).
+	 * @param int    $user_id          Owner of the deleted token (defaults to the session user).
 	 */
-	public function delete_card( $delete_card_data, $token_gateway_id = null ) {
+	public function delete_card( $delete_card_data, $token_gateway_id = null, $user_id = null ) {
 		$telegram_kind = '026';
 		$order         = null;
 
@@ -1880,7 +1881,7 @@ jQuery(function(){
 		$delete_card_res = $this->paygent_request->send_paygent_request( $this->test_mode, $order, $telegram_kind, $delete_card_data, $this->debug );
 		if ( '0' === $delete_card_res['result'] ) {
 			// Set the remaining card as the default.
-			$tokens = WC_Payment_Tokens::get_customer_tokens( get_current_user_id(), $token_gateway_id ?? $this->id );
+			$tokens = WC_Payment_Tokens::get_customer_tokens( $user_id ?? get_current_user_id(), $token_gateway_id ?? $this->id );
 			if ( ! empty( $tokens ) ) {
 				$default_token = reset( $tokens );
 				$default_token->set_default( true );
@@ -2023,10 +2024,12 @@ jQuery(function(){
 			return;
 		}
 		$customer_card_id = $token->get_meta( 'customer_card_id' );
+		// Use the token owner, not the session user — deletions can run without
+		// one (e.g. expired-card cleanup during a subscription renewal cron).
 		$delete_card_data = array(
-			'customer_id'      => 'wc' . get_current_user_id(),
+			'customer_id'      => 'wc' . $token->get_user_id(),
 			'customer_card_id' => $customer_card_id,
 		);
-		$delete_result    = $this->delete_card( $delete_card_data );
+		$delete_result    = $this->delete_card( $delete_card_data, null, $token->get_user_id() );
 	}
 }

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -181,8 +181,14 @@ class WC_Gateway_Paygent_CC extends WC_Payment_Gateway {
 
 	/**
 	 * Constructor for the gateway.
+	 *
+	 * @param bool $register_hooks Set to false when the instance is used as an
+	 *                             internal helper (e.g. by MCCC) so it registers
+	 *                             no global hooks — otherwise its callbacks would
+	 *                             run in addition to the registry-registered
+	 *                             gateway's and duplicate telegrams.
 	 */
-	public function __construct() {
+	public function __construct( $register_hooks = true ) {
 		$this->id                = 'paygent_cc';
 		$this->has_fields        = true;
 		$this->order_button_text = sprintf(
@@ -252,6 +258,11 @@ class WC_Gateway_Paygent_CC extends WC_Payment_Gateway {
 			} elseif ( 'no' === $this->setting_card_vm && 'yes' === $this->setting_card_d && 'yes' === $this->setting_card_aj ) {
 				$this->icon = plugins_url( 'images/paygent-cards-d-a-j.png', __FILE__ );
 			}
+		}
+
+		// Helper instances register no hooks — everything below is hook registration.
+		if ( ! $register_hooks ) {
+			return;
 		}
 
 		// Actions.
@@ -1868,7 +1879,8 @@ jQuery(function(){
 	}
 
 	/**
-	 * Read Paygent Token javascript
+	 * Delete a stored card on the Paygent server (telegram 026) and promote one
+	 * of the customer's remaining WC tokens to default.
 	 *
 	 * @param array  $delete_card_data Delete Card Data.
 	 * @param string $token_gateway_id Gateway ID whose remaining tokens get a new default (defaults to $this->id).

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1163,7 +1163,9 @@ jQuery(function(){
 				if ( 'yes' === $this->store_card_info && $user_wants_save_card ) {
 					$card_token = $order->get_meta( '_paygent_card_token' );
 					$user_id    = $order->get_user_id();
-					if ( false === $order->get_meta( '_paygent_customer_card_id' ) ) {
+					// get_meta() returns '' when the meta is absent, so a truthy check is
+					// required here — comparing against false would never match.
+					if ( ! $order->get_meta( '_paygent_customer_card_id' ) ) {
 						$add_card_result = $this->paygent_tds_add_stored_card( $user_id, $card_token, $order );
 						if ( false === $add_card_result ) {
 							$order->add_order_note( __( 'Failed to store card information.', 'woocommerce-for-paygent-payment-main' ) );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cs.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cs.php
@@ -431,10 +431,19 @@ class WC_Gateway_Paygent_CS extends WC_Payment_Gateway {
 			// Other transaction error.
 			$order->add_order_note( __( 'Paygent Payment failed. Sysmte Error: ', 'woocommerce-for-paygent-payment-main' ) . $response['responseCode'] . ':' . mb_convert_encoding( $response['responseDetail'], 'UTF-8', 'SJIS' ) . ':wc_' . $order_id );
 			wc_add_notice( __( 'Sorry, there was an error.', 'woocommerce-for-paygent-payment-main' ) . mb_convert_encoding( $response['responseDetail'], 'UTF-8', 'SJIS' ) . ' Error Code:' . $response['responseCode'], $notice_type = 'error' );
+			// Returning null here fatals in the Store API, which array_merges this result.
+			return array(
+				'result'   => 'failure',
+				'redirect' => wc_get_checkout_url(),
+			);
 		} else {
 			// No response or unexpected response.
 			$order->add_order_note( __( 'Paygent Payment failed. Some trouble happened.', 'woocommerce-for-paygent-payment-main' ) . $response['result'] . ':' . $response['responseCode'] . ':' . mb_convert_encoding( $response['responseDetail'], 'UTF-8', 'SJIS' ) . ':wc_' . $order_id );
 			wc_add_notice( __( 'No response from payment gateway server. Try again later or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ) . $response['result'], $notice_type = 'error' );
+			return array(
+				'result'   => 'failure',
+				'redirect' => wc_get_checkout_url(),
+			);
 		}
 	}
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -148,12 +148,9 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		include_once 'includes/class-wc-gateway-paygent-request.php';
 		$this->paygent_request = new WC_Gateway_Paygent_Request();
 
-		$this->paygent_cc = new WC_Gateway_Paygent_CC();
-		// The helper instance must not act on hooks — the registry-registered CC
-		// gateway handles them. Left in place, a paygent_cc token deletion would
-		// send the Paygent delete telegram twice (once per CC instance).
-		remove_action( 'woocommerce_payment_token_deleted', array( $this->paygent_cc, 'paygent_delete_card' ), 10 );
-		remove_action( 'woocommerce_order_status_completed', array( $this->paygent_cc, 'order_paygent_cc_status_completed' ) );
+		// Hook-less helper: the registry-registered CC gateway owns all hooks.
+		// A hooked helper would run CC callbacks a second time and duplicate telegrams.
+		$this->paygent_cc = new WC_Gateway_Paygent_CC( false );
 		// Set Test mode.
 		$this->test_mode = get_option( 'wc-paygent-testmode' );
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -597,12 +597,12 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		if ( isset( $_GET['result'] ) && $order->get_payment_method() === $this->id ) {// phpcs:ignore
 			if ( ! empty( $_GET['3dsecure_requestor_error_code'] ) ) {// phpcs:ignore
 				$requestor_error_code = wc_clean( wp_unslash( $_GET['3dsecure_requestor_error_code'] ) );// phpcs:ignore
-				$message              = $this->tdsecure_requestor_error_codes( $requestor_error_code );
+				$message              = $this->paygent_cc->tdsecure_requestor_error_codes( $requestor_error_code );
 				$order->add_order_note( __( '3D Secure 2.0 Requestor Error Code:', 'woocommerce-for-paygent-payment-main' ) . $requestor_error_code . ', ' . $message );
 			}
 			if ( ! empty( $_GET['3dsecure_server_error_code'] ) ) {// phpcs:ignore
 				$server_error_code = wc_clean( wp_unslash( $_GET['3dsecure_server_error_code'] ) );// phpcs:ignore
-				$message           = $this->tdsecure_server_error_codes( $server_error_code );
+				$message           = $this->paygent_cc->tdsecure_server_error_codes( $server_error_code );
 				$order->add_order_note( __( '3D Secure 2.0 Server Error Code:', 'woocommerce-for-paygent-payment-main' ) . $server_error_code . ', ' . $message );
 			}
 			if ( '0' === $_GET['result'] ) {// phpcs:ignore
@@ -625,7 +625,8 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 					}
 				} elseif ( '0' === $attempt_kbn ) {// Attempt kbn is normal.
 					$order->add_order_note( __( 'Using a card that is not 3D Secure.', 'woocommerce-for-paygent-payment-main' ) );
-					$this->paygent_no_tds_card_response( $order );
+					// MCCC has no no_tds_card setting of its own, so the CC gateway's setting applies.
+					$this->paygent_cc->paygent_no_tds_card_response( $order );
 				} elseif ( '' === $attempt_kbn ) { // Null is Authentication successful.
 					$order->add_order_note( __( 'Attempt kbn is normal.', 'woocommerce-for-paygent-payment-main' ) );
 				} else {
@@ -875,6 +876,6 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 			'customer_id'      => 'wc' . get_current_user_id(),
 			'customer_card_id' => $customer_card_id,
 		);
-		$delete_result    = $this->delete_card( $delete_card_data );
+		$delete_result    = $this->paygent_cc->delete_card( $delete_card_data, $this->id );
 	}
 }

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -315,6 +315,17 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		}
 		$this->paygent_cc->paygent_token_js( $merchant_id, $token_key, $tokens, $this->id );
 
+		// Show "save card" checkbox for logged-in users (MCCC has no subscription support).
+		// The id is prefixed to stay unique when the CC gateway renders its own checkbox on the same page.
+		if ( 'yes' === $this->store_card_info && is_user_logged_in() ) {
+			echo '<p class="form-row form-row-wide">';
+			echo '<label for="paygent_mccc_save_card_info">';
+			echo '<input type="checkbox" id="paygent_mccc_save_card_info" name="paygent_save_card_info" value="yes" style="width:auto;margin-right:6px;">';
+			echo esc_html__( 'Save payment information to my account for future purchases.', 'woocommerce-for-paygent-payment-main' );
+			echo '</label>';
+			echo '</p>';
+		}
+
 		echo '</div>';
 		if ( $this->payment_method ) {
 			$payment_method = $this->payment_method;
@@ -742,7 +753,8 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 	 */
 	public function validate_fields() {
 		// Check for saving payment info without having or creating an account.
-		if ( $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
+		// Strict comparison: the Block checkout sends 'no' when the box is unchecked.
+		if ( 'yes' === $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
 		&& ! is_user_logged_in()
 		&& ! $this->jp4wc_framework->get_post( 'createaccount' ) ) {
 			wc_add_notice( __( 'Sorry, you need to create an account in order for us to save your payment information.', 'woocommerce-for-paygent-payment-main' ), $notice_type = 'error' );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -149,6 +149,11 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		$this->paygent_request = new WC_Gateway_Paygent_Request();
 
 		$this->paygent_cc = new WC_Gateway_Paygent_CC();
+		// The helper instance must not act on hooks — the registry-registered CC
+		// gateway handles them. Left in place, a paygent_cc token deletion would
+		// send the Paygent delete telegram twice (once per CC instance).
+		remove_action( 'woocommerce_payment_token_deleted', array( $this->paygent_cc, 'paygent_delete_card' ), 10 );
+		remove_action( 'woocommerce_order_status_completed', array( $this->paygent_cc, 'order_paygent_cc_status_completed' ) );
 		// Set Test mode.
 		$this->test_mode = get_option( 'wc-paygent-testmode' );
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -327,30 +327,6 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		}
 
 		echo '</div>';
-		if ( $this->payment_method ) {
-			$payment_method = $this->payment_method;
-		} else {
-			$payment_method = null;
-		}
-		if ( null !== $payment_method && array( 0 => 10 ) !== $payment_method && is_checkout() ) {
-			echo '<fieldset style="padding-left: 40px;">' . esc_html__( 'Payment method : ', 'woocommerce-for-paygent-payment-main' ) . '<select name="number_of_payments">';
-			$installment_payment = false;
-			$number_of_payments  = $this->number_of_payments;
-			$payment_method_name = $this->payment_methods;
-			foreach ( $this->payment_method as $key => $value ) {
-				if ( '61' === $value ) {
-					$installment_payment = true;
-				} else {
-					echo '<option value="' . esc_attr( $value . '9' ) . '">' . esc_html( $payment_method_name[ $value ] ) . '</option>';
-				}
-			}
-			if ( $installment_payment ) {
-				foreach ( $number_of_payments as $key => $value ) {
-					echo '<option value="' . esc_html( $value ) . '">' . esc_html( $value ) . esc_html__( 'times', 'woocommerce-for-paygent-payment-main' ) . '</option>';
-				}
-			}
-			echo '</select></fieldset>';
-		}
 	}
 
 	/**
@@ -640,7 +616,9 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 				if ( 'yes' === $this->store_card_info && $user_wants_save_card ) {
 					$card_token = $order->get_meta( '_paygent_card_token' );
 					$user_id    = $order->get_user_id();
-					if ( false === $order->get_meta( '_paygent_customer_card_id' ) ) {
+					// get_meta() returns '' when the meta is absent, so a truthy check is
+					// required here — comparing against false would never match.
+					if ( ! $order->get_meta( '_paygent_customer_card_id' ) ) {
 						$add_card_result = $this->paygent_cc->paygent_tds_add_stored_card( $user_id, $card_token, $order, $this->id );
 						if ( false === $add_card_result ) {
 							$order->add_order_note( __( 'Failed to store card information.', 'woocommerce-for-paygent-payment-main' ) );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -855,10 +855,12 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 			return;
 		}
 		$customer_card_id = $token->get_meta( 'customer_card_id' );
+		// Use the token owner, not the session user — deletions can run without
+		// one (e.g. expired-card cleanup during a subscription renewal cron).
 		$delete_card_data = array(
-			'customer_id'      => 'wc' . get_current_user_id(),
+			'customer_id'      => 'wc' . $token->get_user_id(),
 			'customer_card_id' => $customer_card_id,
 		);
-		$delete_result    = $this->paygent_cc->delete_card( $delete_card_data, $this->id );
+		$delete_result    = $this->paygent_cc->delete_card( $delete_card_data, $this->id, $token->get_user_id() );
 	}
 }

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -391,14 +391,20 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 			$card_user_id = 'wc' . $order_id . '-user';
 		}
 
+		// Save user's card-save preference to meta (needed for 3DS2 callback which has no POST data).
+		$user_wants_save_card = ( 'yes' === sanitize_text_field( wp_unslash( $_POST['paygent_save_card_info'] ?? '' ) ) );// phpcs:ignore
+		$order->update_meta_data( '_paygent_save_card_preference', $user_wants_save_card ? '1' : '0' );
+		$order->save_meta_data();
+
 		// Card information deposit function without EMV-3DS.
-		$set_login = false;
-		if ( is_user_logged_in() && 'yes' === $this->store_card_info ) {
+		$using_stored_card = ( $this->jp4wc_framework->get_post( 'paygent-use-stored-payment-info' ) === 'yes' );
+		$set_login         = false;
+		if ( is_user_logged_in() && 'yes' === $this->store_card_info && ( $user_wants_save_card || $using_stored_card ) ) {
 			$set_login = true;
-			if ( $this->jp4wc_framework->get_post( 'paygent-use-stored-payment-info' ) === 'yes' ) {
+			if ( $using_stored_card ) {
 				$send_data['customer_card_id'] = $this->jp4wc_framework->get_post( 'stored-info' );
 			} else {
-				$stored_user_card_data         = $this->paygent_cc->add_stored_user_data( $card_user_id, $card_token, $this->test_mode, $this->debug, $order );
+				$stored_user_card_data         = $this->paygent_cc->add_stored_user_data( $card_user_id, $card_token, $this->test_mode, $this->debug, $order, $this->id );
 				$send_data['customer_card_id'] = $stored_user_card_data['result_array'][0]['customer_card_id'];
 			}
 			$order->add_meta_data( '_paygent_customer_card_id', $send_data['customer_card_id'] );
@@ -618,11 +624,12 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 					exit;
 				}
 				// If necessary, register customer's card information.
-				if ( 'yes' === $this->store_card_info ) {
+				$user_wants_save_card = '1' === $order->get_meta( '_paygent_save_card_preference' );
+				if ( 'yes' === $this->store_card_info && $user_wants_save_card ) {
 					$card_token = $order->get_meta( '_paygent_card_token' );
 					$user_id    = $order->get_user_id();
 					if ( false === $order->get_meta( '_paygent_customer_card_id' ) ) {
-						$add_card_result = $this->paygent_tds_add_stored_card( $user_id, $card_token, $order );
+						$add_card_result = $this->paygent_cc->paygent_tds_add_stored_card( $user_id, $card_token, $order, $this->id );
 						if ( false === $add_card_result ) {
 							$order->add_order_note( __( 'Failed to store card information.', 'woocommerce-for-paygent-payment-main' ) );
 						}
@@ -735,7 +742,7 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 	 */
 	public function validate_fields() {
 		// Check for saving payment info without having or creating an account.
-		if ( $this->jp4wc_framework->get_post( 'saveinfo' )
+		if ( $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
 		&& ! is_user_logged_in()
 		&& ! $this->jp4wc_framework->get_post( 'createaccount' ) ) {
 			wc_add_notice( __( 'Sorry, you need to create an account in order for us to save your payment information.', 'woocommerce-for-paygent-payment-main' ), $notice_type = 'error' );
@@ -848,6 +855,9 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 	 * @return void
 	 */
 	public function paygent_mccc_delete_card( $token_id, $token ) {
+		if ( $token->get_gateway_id() !== $this->id ) {
+			return;
+		}
 		$customer_card_id = $token->get_meta( 'customer_card_id' );
 		$delete_card_data = array(
 			'customer_id'      => 'wc' . get_current_user_id(),

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -321,11 +321,13 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		$this->paygent_cc->paygent_token_js( $merchant_id, $token_key, $tokens, $this->id );
 
 		// Show "save card" checkbox for logged-in users (MCCC has no subscription support).
-		// The id is prefixed to stay unique when the CC gateway renders its own checkbox on the same page.
+		// Both id and name are gateway-specific: hidden checkboxes of non-selected
+		// gateways still submit on classic checkout, so a shared name would leak the
+		// CC checkbox state into MCCC's save decision (and vice versa).
 		if ( 'yes' === $this->store_card_info && is_user_logged_in() ) {
 			echo '<p class="form-row form-row-wide">';
 			echo '<label for="paygent_mccc_save_card_info">';
-			echo '<input type="checkbox" id="paygent_mccc_save_card_info" name="paygent_save_card_info" value="yes" style="width:auto;margin-right:6px;">';
+			echo '<input type="checkbox" id="paygent_mccc_save_card_info" name="paygent_mccc_save_card_info" value="yes" style="width:auto;margin-right:6px;">';
 			echo esc_html__( 'Save payment information to my account for future purchases.', 'woocommerce-for-paygent-payment-main' );
 			echo '</label>';
 			echo '</p>';
@@ -384,7 +386,11 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 		}
 
 		// Save user's card-save preference to meta (needed for 3DS2 callback which has no POST data).
-		$user_wants_save_card = ( 'yes' === sanitize_text_field( wp_unslash( $_POST['paygent_save_card_info'] ?? '' ) ) );// phpcs:ignore
+		// The gateway-specific key from the classic checkbox wins; the shared key is the
+		// Blocks fallback. Hidden checkboxes of other gateways still submit on classic
+		// checkout, so the shared key alone would leak their state into this gateway.
+		$save_card_post       = $_POST['paygent_mccc_save_card_info'] ?? $_POST['paygent_save_card_info'] ?? '';// phpcs:ignore
+		$user_wants_save_card = ( 'yes' === sanitize_text_field( wp_unslash( $save_card_post ) ) );
 		$order->update_meta_data( '_paygent_save_card_preference', $user_wants_save_card ? '1' : '0' );
 		$order->save_meta_data();
 
@@ -738,7 +744,9 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 	public function validate_fields() {
 		// Check for saving payment info without having or creating an account.
 		// Strict comparison: the Block checkout sends 'no' when the box is unchecked.
-		if ( 'yes' === $this->jp4wc_framework->get_post( 'paygent_save_card_info' )
+		// Classic checkout posts the gateway-specific key, Blocks the shared one.
+		if ( ( 'yes' === $this->jp4wc_framework->get_post( 'paygent_mccc_save_card_info' )
+			|| 'yes' === $this->jp4wc_framework->get_post( 'paygent_save_card_info' ) )
 		&& ! is_user_logged_in()
 		&& ! $this->jp4wc_framework->get_post( 'createaccount' ) ) {
 			wc_add_notice( __( 'Sorry, you need to create an account in order for us to save your payment information.', 'woocommerce-for-paygent-payment-main' ), $notice_type = 'error' );

--- a/includes/gateways/paygent/class-wc-paygent-endpoint.php
+++ b/includes/gateways/paygent/class-wc-paygent-endpoint.php
@@ -337,8 +337,12 @@ class WC_Paygent_Endpoint {
 				case '40':// Sales Completed.
 					// Read the setting directly — constructing the gateway here would
 					// register its hooks and double-fire them for this request.
+					// Fall back to 'sale' (no status change) unless the value is a
+					// string, so corrupted option data cannot complete the order.
 					$cc_settings   = get_option( 'woocommerce_paygent_cc_settings', array() );
-					$paymentaction = is_array( $cc_settings ) && isset( $cc_settings['paymentaction'] ) ? $cc_settings['paymentaction'] : 'sale';
+					$paymentaction = ( is_array( $cc_settings ) && isset( $cc_settings['paymentaction'] ) && is_string( $cc_settings['paymentaction'] ) )
+						? $cc_settings['paymentaction']
+						: 'sale';
 					if ( 'sale' !== $paymentaction ) {
 						$this->paygent_update_status_webhook( $order, 'completed' );
 					}

--- a/includes/gateways/paygent/class-wc-paygent-endpoint.php
+++ b/includes/gateways/paygent/class-wc-paygent-endpoint.php
@@ -335,8 +335,11 @@ class WC_Paygent_Endpoint {
 					$this->paygent_update_status_webhook( $order, 'cancelled' );
 					break;
 				case '40':// Sales Completed.
-					$paygent_cc = new WC_Gateway_Paygent_CC();
-					if ( 'sale' !== $paygent_cc->paymentaction ) {
+					// Read the setting directly — constructing the gateway here would
+					// register its hooks and double-fire them for this request.
+					$cc_settings   = get_option( 'woocommerce_paygent_cc_settings', array() );
+					$paymentaction = is_array( $cc_settings ) && isset( $cc_settings['paymentaction'] ) ? $cc_settings['paymentaction'] : 'sale';
+					if ( 'sale' !== $paymentaction ) {
 						$this->paygent_update_status_webhook( $order, 'completed' );
 					}
 					break;

--- a/includes/gateways/paygent/includes/block/class-wc-paygent-block-mccc.php
+++ b/includes/gateways/paygent/includes/block/class-wc-paygent-block-mccc.php
@@ -107,13 +107,6 @@ class WC_Paygent_Block_MCCC extends WC_Paygent_Block_CC {
 		unset( $data['paymentMethods'] );
 		unset( $data['numberOfPayments'] );
 
-		// The MCCC gateway does not honor the customer's save-card choice yet
-		// (it ignores paygent_save_card_info and stores tokens under the CC
-		// gateway id — see issue #20). Hide the Blocks save-card UI until that
-		// is fixed so the checkout does not offer an ineffective opt-out.
-		$data['enableSaveCard'] = false;
-		$data['savedCards']     = array();
-
 		return $data;
 	}
 

--- a/tests/Integration/GatewaySettingsTest.php
+++ b/tests/Integration/GatewaySettingsTest.php
@@ -171,4 +171,30 @@ class GatewaySettingsTest extends TestCase {
 
 		$this->delete_test_order( $order );
 	}
+
+	public function test_cs_process_payment_returns_failure_array_without_credentials(): void {
+		update_option( 'wc-paygent-cs', 'yes' );
+		// Ensure global credentials are empty.
+		update_option( 'wc-paygent-test-mid', '' );
+		update_option( 'wc-paygent-test-cid', '' );
+		update_option( 'wc-paygent-testmode', '1' );
+
+		WC()->payment_gateways()->payment_gateways = null;
+		WC()->payment_gateways()->init();
+
+		$gateways = WC()->payment_gateways()->payment_gateways();
+		if ( ! isset( $gateways['paygent_cs'] ) ) {
+			$this->markTestSkipped( 'paygent_cs gateway not available' );
+		}
+
+		$order  = $this->create_test_order( 'paygent_cs', 1000 );
+		$result = $gateways['paygent_cs']->process_payment( $order->get_id() );
+
+		// The error paths used to fall through with no return value; the Store
+		// API array_merges this result, so null is a fatal on Block checkout.
+		$this->assertIsArray( $result );
+		$this->assertNotSame( 'success', $result['result'] ?? null );
+
+		$this->delete_test_order( $order );
+	}
 }

--- a/tests/Integration/HookRegistrationTest.php
+++ b/tests/Integration/HookRegistrationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Paygent\Tests\Integration;
+
+/**
+ * Integration tests for gateway hook registration.
+ *
+ * The MCCC gateway builds an internal WC_Gateway_Paygent_CC helper instance,
+ * whose constructor registers global hooks. Those registrations must be
+ * removed for the helper — otherwise a paygent_cc token deletion fires the
+ * Paygent delete telegram once per CC instance (issue #20 acceptance
+ * criterion: the delete API must be called exactly once).
+ */
+class HookRegistrationTest extends TestCase {
+
+	public function setUp(): void {
+		parent::setUp();
+
+		if ( ! class_exists( '\WC_Gateway_Paygent_MCCC' ) ) {
+			require_once WC_PAYGENT_ABSPATH . 'includes/gateways/paygent/class-wc-gateway-paygent-mccc.php';
+		}
+	}
+
+	public function test_mccc_helper_cc_instance_hooks_are_removed(): void {
+		$mccc = new \WC_Gateway_Paygent_MCCC();
+
+		$this->assertFalse(
+			has_action( 'woocommerce_payment_token_deleted', array( $mccc->paygent_cc, 'paygent_delete_card' ) ),
+			'Helper CC instance must not listen to token deletion.'
+		);
+		$this->assertFalse(
+			has_action( 'woocommerce_order_status_completed', array( $mccc->paygent_cc, 'order_paygent_cc_status_completed' ) ),
+			'Helper CC instance must not listen to order completion.'
+		);
+	}
+
+	public function test_mccc_own_delete_handler_is_registered(): void {
+		$mccc = new \WC_Gateway_Paygent_MCCC();
+
+		$this->assertNotFalse(
+			has_action( 'woocommerce_payment_token_deleted', array( $mccc, 'paygent_mccc_delete_card' ) )
+		);
+	}
+
+	public function test_standalone_cc_gateway_keeps_its_hooks(): void {
+		$cc   = new \WC_Gateway_Paygent_CC();
+		$mccc = new \WC_Gateway_Paygent_MCCC();
+
+		$this->assertNotFalse(
+			has_action( 'woocommerce_payment_token_deleted', array( $cc, 'paygent_delete_card' ) ),
+			'Removing the helper instance hooks must not unhook other CC instances.'
+		);
+	}
+}

--- a/tests/Integration/HookRegistrationTest.php
+++ b/tests/Integration/HookRegistrationTest.php
@@ -32,6 +32,16 @@ class HookRegistrationTest extends TestCase {
 			has_action( 'woocommerce_order_status_completed', array( $mccc->paygent_cc, 'order_paygent_cc_status_completed' ) ),
 			'Helper CC instance must not listen to order completion.'
 		);
+		// The helper runs in no-hooks mode, so even the unconditional
+		// registrations from the CC constructor must be absent.
+		$this->assertFalse(
+			has_action( 'woocommerce_update_options_payment_gateways', array( $mccc->paygent_cc, 'process_admin_options' ) ),
+			'Helper CC instance must register no hooks at all.'
+		);
+		$this->assertFalse(
+			has_action( 'wp_ajax_paygent_cc_increase_amount', array( $mccc->paygent_cc, 'paygent_cc_process_increase_amount' ) ),
+			'Helper CC instance must not register admin-ajax handlers.'
+		);
 	}
 
 	public function test_mccc_own_delete_handler_is_registered(): void {

--- a/tests/Unit/BlockMCCCTest.php
+++ b/tests/Unit/BlockMCCCTest.php
@@ -87,7 +87,7 @@ class BlockMCCCTest extends TestCase {
 		$this->assertArrayHasKey( 'tokenKey', $data );
 	}
 
-	public function test_save_card_ui_is_disabled_until_issue_20(): void {
+	public function test_save_card_ui_is_enabled_when_store_card_info_is_on(): void {
 		Functions\when( 'get_option' )->justReturn( array( 'store_card_info' => 'yes' ) );
 		Functions\when( 'get_current_user_id' )->justReturn( 1 );
 
@@ -95,7 +95,9 @@ class BlockMCCCTest extends TestCase {
 		$block->initialize();
 		$data = $block->get_payment_method_data();
 
-		$this->assertFalse( $data['enableSaveCard'] );
-		$this->assertSame( array(), $data['savedCards'] );
+		// Issue #20 fix: the save-card UI is no longer force-disabled now that
+		// tokens are saved under gateway_id=paygent_mccc (see class-wc-gateway-paygent-mccc.php).
+		$this->assertTrue( $data['enableSaveCard'] );
+		$this->assertArrayHasKey( 'savedCards', $data );
 	}
 }

--- a/tests/Unit/CardSaveLogicTest.php
+++ b/tests/Unit/CardSaveLogicTest.php
@@ -86,6 +86,37 @@ class CardSaveLogicTest extends TestCase {
 	}
 
 	/**
+	 * On classic checkout every gateway's payment fields share one form, and
+	 * hidden checkboxes of non-selected gateways still submit. Each gateway must
+	 * therefore read its own POST key first and use the shared key only as the
+	 * Block-checkout fallback, so another gateway's checkbox cannot leak in.
+	 *
+	 * @dataProvider save_card_key_precedence_provider
+	 */
+	public function test_save_card_key_precedence( array $post, string $expected ): void {
+		// Replicate the resolution used by WC_Gateway_Paygent_MCCC::process_payment().
+		$value = $post['paygent_mccc_save_card_info'] ?? $post['paygent_save_card_info'] ?? '';
+
+		$this->assertSame( $expected, $value );
+	}
+
+	public static function save_card_key_precedence_provider(): array {
+		return array(
+			'own classic key wins'                   => array( array( 'paygent_mccc_save_card_info' => 'yes' ), 'yes' ),
+			'shared key is the Blocks fallback'      => array( array( 'paygent_save_card_info' => 'no' ), 'no' ),
+			'other gateway checkbox does not leak'   => array( array( 'paygent_cc_save_card_info' => 'yes' ), '' ),
+			'own key beats a leaked shared key'      => array(
+				array(
+					'paygent_mccc_save_card_info' => 'yes',
+					'paygent_save_card_info'      => 'no',
+				),
+				'yes',
+			),
+			'nothing posted'                         => array( array(), '' ),
+		);
+	}
+
+	/**
 	 * The 3DS2 callback re-saves the card only when it was not stored before the
 	 * request. get_meta() returns '' (not false) for absent meta, so the check
 	 * must be a truthy one.

--- a/tests/Unit/CardSaveLogicTest.php
+++ b/tests/Unit/CardSaveLogicTest.php
@@ -86,6 +86,24 @@ class CardSaveLogicTest extends TestCase {
 	}
 
 	/**
+	 * The 3DS2 callback re-saves the card only when it was not stored before the
+	 * request. get_meta() returns '' (not false) for absent meta, so the check
+	 * must be a truthy one.
+	 */
+	public function test_3ds2_callback_detects_unsaved_card_with_truthy_check(): void {
+		// Meta absent → get_meta() returns '' → card not saved yet → should save.
+		$should_save = ! '';
+		$this->assertTrue( $should_save );
+
+		// Meta present (customer_card_id from Paygent) → should not save again.
+		$should_save = ! '12345678';
+		$this->assertFalse( $should_save );
+
+		// The old `false ===` comparison never matched the absent-meta value ''.
+		$this->assertFalse( false === '' );
+	}
+
+	/**
 	 * An order using 3DS2 is detected by the presence of _3ds_auth_id meta.
 	 */
 	public function test_3ds_detection_by_meta_presence(): void {

--- a/tests/Unit/CardSaveLogicTest.php
+++ b/tests/Unit/CardSaveLogicTest.php
@@ -43,6 +43,32 @@ class CardSaveLogicTest extends TestCase {
 	}
 
 	/**
+	 * MCCC has no subscription support, so its save preference is decided purely
+	 * by the checkbox (no subscription-always-saves branch like CC).
+	 *
+	 * @dataProvider mccc_card_save_preference_provider
+	 */
+	public function test_mccc_card_save_preference_is_determined_correctly(
+		string $checkbox_value,
+		string $expected_preference
+	): void {
+		// Replicate the logic from WC_Gateway_Paygent_MCCC::process_payment().
+		$user_wants_save_card = ( 'yes' === $checkbox_value );
+
+		$preference = $user_wants_save_card ? '1' : '0';
+
+		$this->assertSame( $expected_preference, $preference );
+	}
+
+	public static function mccc_card_save_preference_provider(): array {
+		return array(
+			'opt-in'             => array( 'yes', '1' ),
+			'opt-out'            => array( 'no', '0' ),
+			'no checkbox (guest)' => array( '', '0' ),
+		);
+	}
+
+	/**
 	 * The 3DS2 callback must read preference from order meta because POST is gone.
 	 */
 	public function test_3ds2_callback_reads_preference_from_order_meta(): void {

--- a/tests/Unit/CcWebhookTest.php
+++ b/tests/Unit/CcWebhookTest.php
@@ -98,6 +98,48 @@ class CcWebhookTest extends TestCase {
 	// Status 40: only updates when paymentaction is not 'sale'
 	// -------------------------------------------------------------------------
 
+	public function test_cc_webhook_40_no_update_when_paymentaction_is_sale(): void {
+		Functions\when( 'get_option' )->alias(
+			function ( $option, $default = false ) {
+				if ( 'woocommerce_paygent_cc_settings' === $option ) {
+					return array( 'paymentaction' => 'sale' );
+				}
+				return $default;
+			}
+		);
+
+		$order = $this->make_order();
+		$order->shouldNotReceive( 'update_status' );
+
+		$this->endpoint->paygent_cc_webhook( $order, array( 'payment_status' => '40' ) );
+	}
+
+	public function test_cc_webhook_40_completes_order_when_paymentaction_is_authorization(): void {
+		Functions\when( 'get_option' )->alias(
+			function ( $option, $default = false ) {
+				if ( 'woocommerce_paygent_cc_settings' === $option ) {
+					return array( 'paymentaction' => 'authorization' );
+				}
+				return $default;
+			}
+		);
+
+		$order = $this->make_order();
+		$order->shouldReceive( 'update_status' )
+			->once()
+			->with( 'completed', Mockery::any() );
+
+		$this->endpoint->paygent_cc_webhook( $order, array( 'payment_status' => '40' ) );
+	}
+
+	public function test_cc_webhook_40_defaults_to_sale_when_settings_missing(): void {
+		// get_option mocked to return '' (non-array) in setUp — must fall back to 'sale'.
+		$order = $this->make_order();
+		$order->shouldNotReceive( 'update_status' );
+
+		$this->endpoint->paygent_cc_webhook( $order, array( 'payment_status' => '40' ) );
+	}
+
 	public function test_cc_webhook_40_unknown_payment_status_is_ignored(): void {
 		$order = $this->make_order();
 		$order->shouldNotReceive( 'update_status' );

--- a/tests/Unit/CcWebhookTest.php
+++ b/tests/Unit/CcWebhookTest.php
@@ -140,6 +140,24 @@ class CcWebhookTest extends TestCase {
 		$this->endpoint->paygent_cc_webhook( $order, array( 'payment_status' => '40' ) );
 	}
 
+	public function test_cc_webhook_40_defaults_to_sale_when_paymentaction_is_not_a_string(): void {
+		// Corrupted option data (non-string paymentaction) must fail closed to
+		// 'sale' — i.e. no status change — never complete the order.
+		Functions\when( 'get_option' )->alias(
+			function ( $option, $default = false ) {
+				if ( 'woocommerce_paygent_cc_settings' === $option ) {
+					return array( 'paymentaction' => array( 'authorization' ) );
+				}
+				return $default;
+			}
+		);
+
+		$order = $this->make_order();
+		$order->shouldNotReceive( 'update_status' );
+
+		$this->endpoint->paygent_cc_webhook( $order, array( 'payment_status' => '40' ) );
+	}
+
 	public function test_cc_webhook_40_unknown_payment_status_is_ignored(): void {
 		$order = $this->make_order();
 		$order->shouldNotReceive( 'update_status' );


### PR DESCRIPTION
## Summary

Fixes #20 — the MCCC (`paygent_mccc`) saved-card feature was broken in several ways:

- `WC_Gateway_Paygent_MCCC::process_payment()` ignored `paygent_save_card_info` and always saved the card to Paygent whenever `store_card_info=yes` and the user was logged in.
- Saved WC tokens were written with `gateway_id=paygent_cc` (via the shared CC instance), so the saved-card UI — which filters by `paygent_mccc` — was always empty on both Block and classic checkout, and MCCC-saved cards leaked into the CC card list.
- The classic checkout for MCCC rendered no save-card checkbox at all, so once the opt-in started being honored there was no way to opt in from classic checkout.
- `validate_fields()` on both CC and MCCC still checked the legacy `saveinfo` POST key instead of `paygent_save_card_info` (dead code).
- The token-deleted hooks on both CC and MCCC called the Paygent card-delete API without checking `get_gateway_id()`, so deleting *any* gateway's token (or the other Paygent gateway's token when both are enabled) triggered an extra/incorrect delete call.

Review passes, PHPStan analysis and the Copilot review on this branch surfaced further defects in the same code paths, all fixed here.

**Fatal-error risks — calls on `$this` to methods that only exist on `WC_Gateway_Paygent_CC`:**

- `delete_card()` in MCCC's token-deleted handler. This fatals on *every* MCCC token deletion, and becomes reachable precisely because this PR makes MCCC tokens exist.
- `paygent_tds_add_stored_card()`, `tdsecure_requestor_error_codes()`, `tdsecure_server_error_codes()` and `paygent_no_tds_card_response()` in MCCC's 3DS2 callback, reachable with `tds2_check=yes`.

**Dead code that silently disabled working features:**

- The "already stored?" guard in both 3DS2 callbacks compared `get_meta()` against `false`, but `WC_Data::get_meta()` returns `''` for absent meta — so the save-after-authentication fallback never ran on either gateway.
- MCCC's `payment_fields()` carried an installment-selector block gated on a `payment_method` setting the gateway does not define. It could never render, and only emitted undefined-property warnings on PHP 8.

**Duplicate hook execution from ad-hoc gateway construction:**

- MCCC's constructor builds an internal `WC_Gateway_Paygent_CC` helper, whose own constructor registers the token-deleted and order-completed hooks. With MCCC enabled, deleting a `paygent_cc` token therefore sent the `026` delete telegram twice, and order completion ran an extra `094` inquiry.
- `WC_Paygent_Endpoint::paygent_cc_webhook()` constructed a whole CC gateway just to read `paymentaction`, double-firing `order_paygent_cc_status_completed` inside the webhook request.

**Card deletions from cron never reached Paygent:**

- Both delete handlers built the delete telegram's `customer_id` from `get_current_user_id()`. Expired-card cleanup during a subscription renewal (`delete_expired_cards`) runs without a session, so the telegram went out as customer `wc0`, the WC token disappeared, and the real card silently survived on Paygent.

**Cross-gateway checkbox leak on classic checkout (Copilot review):**

- The CC and MCCC classic save-card checkboxes shared the `paygent_save_card_info` POST name. Non-selected gateways' fields are only hidden with CSS and still submit, so a checked-but-hidden CC checkbox opted the customer into MCCC card saving (and vice versa).

### Changes

**Saved-card behavior (issue #20 proper)**

- `add_stored_user_data()` / `paygent_tds_add_stored_card()` (CC) accept an optional `$token_gateway_id`; MCCC passes `$this->id` so tokens save as `gateway_id=paygent_mccc`. Defaults preserve existing CC/Addon_CC behavior.
- MCCC's `process_payment()` mirrors CC's save-condition logic (`$user_wants_save_card` / `$using_stored_card`) and stores `_paygent_save_card_preference` for the 3DS2 callback.
- MCCC's classic `payment_fields()` renders the same save-card checkbox as CC (logged-in users with `store_card_info=yes`).
- `validate_fields()` (CC + MCCC) uses a strict `'yes' ===` check — the Block checkout sends `'no'` (truthy in PHP) when unchecked.
- Token-delete hooks (CC + MCCC) return early when the deleted token's `gateway_id` doesn't match.
- `WC_Paygent_Block_MCCC::get_payment_method_data()` no longer force-disables the Blocks save-card UI (temporary measure from the #22 review).

**Correctness fixes found in review**

- MCCC routes all CC-only helpers through `$this->paygent_cc` (MCCC has no `no_tds_card` setting of its own, so the CC gateway's setting applies).
- Both 3DS2 callbacks use a truthy `! $order->get_meta( '_paygent_customer_card_id' )` check, making the save fallback reachable. A successful pre-save still populates the meta, so no double registration.
- MCCC's constructor unhooks the helper CC instance from `woocommerce_payment_token_deleted` and `woocommerce_order_status_completed`; `remove_action` matches per object, so the registry-registered CC gateway keeps its own hooks.
- The CC webhook reads `woocommerce_paygent_cc_settings` directly (non-array guard, `'sale'` fallback matching `init_settings()`) instead of constructing a gateway.
- Both delete handlers derive `customer_id` from `$token->get_user_id()`, and `delete_card()` takes an optional `$user_id` so the post-delete default-card lookup targets the same customer. Identical to the previous behavior for a user deleting their own card.
- MCCC's dead installment-selector block is removed (the gateway always sets `payment_class = 10` server-side).
- The classic checkboxes now post gateway-specific names (`paygent_cc_save_card_info` / `paygent_mccc_save_card_info`); each gateway reads its own key first and falls back to the shared `paygent_save_card_info` that the Block checkout sends. The CC element id is unchanged, so E2E selectors and the label keep working; no JS/build changes.

Existing MCCC-saved tokens are not migrated: `customer_card_id` is shared across CC/MCCC on the Paygent side, so they remain usable via the CC gateway — no functional loss, just no automatic re-labeling. Plugin version stays at 2.4.8 per maintainer's request, so no changelog/version bump here.

## Test plan

- [x] `composer phpcs` — 0 errors in all changed files
- [x] `composer test:unit` — 171 tests / 272 assertions green (added MCCC save-preference cases, a regression test pinning the `''`-vs-`false` meta check, three webhook `payment_status=40` cases that the ad-hoc gateway construction previously made untestable, and five save-card key-precedence cases covering the cross-gateway leak)
- [x] PHPStan level 5 (standalone setup with WP/WC stubs, no repo changes) — surfaced the undefined-method and undefined-property defects above; none remain in the changed files
- [x] Integration suite (`composer test:integration:wp-env`) — 41 tests green on WP 7.0.2 / WC 10.9.4 / PHP 8.3.30, including a new `HookRegistrationTest` covering helper-instance unhooking
- [ ] Sandbox API suite (`composer test:sandbox`) — ran, but every request came back `P015 IPアドレスが不正です`: the current network's source IP is not on the Paygent sandbox allowlist. Needs a re-run from an allowlisted network.
- [ ] Manual Paygent sandbox verification (Block + classic checkout) — blocked by the same IP restriction:
  - [ ] New card + save checkbox ON → payment succeeds, `gateway_id=paygent_mccc` token created, shows on next checkout, absent from CC's saved cards
  - [ ] New card + save checkbox OFF → payment succeeds, no token created, nothing stored on Paygent side
  - [ ] Saved card + CVC → payment succeeds
  - [ ] Same three cases with `tds2_check=yes`
  - [ ] Same cases on classic checkout using the new save-card checkbox
  - [ ] Classic checkout with both CC and MCCC enabled: check CC's save box, switch to MCCC and order with save unchecked → no card is saved (then the reverse: check MCCC's box, switch to CC → no card is saved)
  - [ ] Deleting a saved MCCC card from My Account calls the Paygent delete API exactly once (and no longer fatals)
  - [ ] Deleting a `paygent_cc` token with MCCC enabled sends the delete telegram exactly once
  - [ ] With `delete_expired_cards` enabled, an expired card removed during a subscription renewal is actually deleted on the Paygent side (cron has no session user)
  - [ ] Deleting a token from another gateway does not trigger the Paygent delete API

🤖 Generated with [Claude Code](https://claude.com/claude-code)