### PR TITLE
fix: show 3D Secure 2.0 challenge failure notice on Block Checkout

### DIFF
--- a/class-wc-gateway-paygent.php
+++ b/class-wc-gateway-paygent.php
@@ -314,6 +314,26 @@ if ( ! class_exists( 'WC_Gateway_Paygent' ) ) :
 		}
 
 		/**
+		 * Whitelisted 3D Secure 2.0 challenge failure messages, keyed by a short code.
+		 *
+		 * Only the code (never free text) travels through the checkout
+		 * redirect URL (`paygent_3ds2_error`), so a crafted query value can
+		 * only select one of these fixed, plugin-authored strings — never
+		 * arbitrary attacker-supplied text impersonating a payment or
+		 * support message.
+		 *
+		 * @return array<string, string> Code => translated message.
+		 */
+		public static function get_3ds2_failure_messages(): array {
+			return array(
+				'auth_failed'     => __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ),
+				'attempt_unknown' => __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ),
+				'no_3ds_card'     => __( 'This payment uses a card that does not have 3D Secure.', 'woocommerce-for-paygent-payment-main' )
+					. ' ' . __( 'Please use a card that supports 3D Secure.', 'woocommerce-for-paygent-payment-main' ),
+			);
+		}
+
+		/**
 		 * Show the 3D Secure 2.0 challenge failure message on Block Checkout.
 		 *
 		 * The card gateway (`class-wc-gateway-paygent-cc.php`) redirects back
@@ -332,7 +352,12 @@ if ( ! class_exists( 'WC_Gateway_Paygent' ) ) :
 			if ( ! is_checkout() || empty( $_GET['paygent_3ds2_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				return;
 			}
-			$message = sanitize_text_field( wp_unslash( $_GET['paygent_3ds2_error'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$code     = sanitize_key( wp_unslash( $_GET['paygent_3ds2_error'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$messages = self::get_3ds2_failure_messages();
+			if ( ! isset( $messages[ $code ] ) ) {
+				return;
+			}
+			$message = $messages[ $code ];
 
 			wp_register_script( 'paygent-3ds2-failure-notice', false, array( 'wp-data', 'wp-notices' ), WC_PAYGENT_VERSION, true );
 			wp_enqueue_script( 'paygent-3ds2-failure-notice' );

--- a/class-wc-gateway-paygent.php
+++ b/class-wc-gateway-paygent.php
@@ -56,6 +56,8 @@ if ( ! class_exists( 'WC_Gateway_Paygent' ) ) :
 			add_action( 'woocommerce_blocks_payment_method_type_registration', array( $this, 'register_block_payment_methods' ) );
 			// Enqueue icon styles on the classic (shortcode) checkout page.
 			add_action( 'wp_enqueue_scripts', array( $this, 'enqueue_checkout_styles' ) );
+			// Surface 3D Secure 2.0 challenge failures on Block Checkout after the redirect back from the card issuer.
+			add_action( 'wp_enqueue_scripts', array( $this, 'render_3ds2_failure_notice' ) );
 		}
 
 		/**
@@ -308,6 +310,38 @@ if ( ! class_exists( 'WC_Gateway_Paygent' ) ) :
 				WC_PAYGENT_PLUGIN_URL . 'assets/css/paygent-checkout.css',
 				array( 'woocommerce-general' ),
 				WC_PAYGENT_VERSION
+			);
+		}
+
+		/**
+		 * Show the 3D Secure 2.0 challenge failure message on Block Checkout.
+		 *
+		 * The card gateway (`class-wc-gateway-paygent-cc.php`) redirects back
+		 * here with a `paygent_3ds2_error` query arg after a failed challenge,
+		 * because `wc_add_notice()` alone never reaches the customer on Block
+		 * Checkout: that redirect is a plain page load, not a Store API
+		 * request, and the Store API discards any session notices that
+		 * weren't raised during its own request/response cycle. Dispatching
+		 * the error into the `core/notices` store client-side is how the
+		 * checkout block itself displays errors, so this reuses the same
+		 * `wc/checkout` notice area instead of introducing a separate one.
+		 *
+		 * @return void
+		 */
+		public function render_3ds2_failure_notice(): void {
+			if ( ! is_checkout() || empty( $_GET['paygent_3ds2_error'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				return;
+			}
+			$message = sanitize_text_field( wp_unslash( $_GET['paygent_3ds2_error'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+			wp_register_script( 'paygent-3ds2-failure-notice', false, array( 'wp-data', 'wp-notices' ), WC_PAYGENT_VERSION, true );
+			wp_enqueue_script( 'paygent-3ds2-failure-notice' );
+			wp_add_inline_script(
+				'paygent-3ds2-failure-notice',
+				sprintf(
+					'window.addEventListener("load",function(){if(window.wp&&wp.data&&wp.data.dispatch("core/notices")){wp.data.dispatch("core/notices").createErrorNotice(%s,{context:"wc/checkout"});}});',
+					wp_json_encode( $message )
+				)
 			);
 		}
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1166,6 +1166,25 @@ jQuery(function(){
 	}
 
 	/**
+	 * Redirect back to checkout after a 3D Secure 2.0 challenge failure.
+	 *
+	 * `wc_add_notice()` here only reaches the customer on classic (shortcode)
+	 * checkout: this runs on the order-pay page the ACS redirects back to,
+	 * a separate full-page load from any Store API request, so Block
+	 * Checkout never surfaces it (Store API discards session notices that
+	 * aren't raised during its own request/response cycle). The message is
+	 * therefore also passed via the redirect URL so the checkout page can
+	 * display it client-side regardless of which checkout is active.
+	 *
+	 * @param string $message Error message to show the customer.
+	 */
+	public function paygent_tds2_failure_redirect( $message ) {
+		wc_add_notice( $message, 'error' );
+		wp_safe_redirect( add_query_arg( 'paygent_3ds2_error', rawurlencode( $message ), wc_get_checkout_url() ) );
+		exit;
+	}
+
+	/**
 	 * Html to display the screen when authorizing 3DS 2.0
 	 *
 	 * @param int $order_id Order ID.
@@ -1207,9 +1226,7 @@ jQuery(function(){
 					if ( 'yes' !== $this->attempt ) {
 						wc_increase_stock_levels( $order_id );
 						$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-						wc_add_notice( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-						wp_safe_redirect( wc_get_checkout_url() );
-						exit;
+						$this->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
 					}
 				} elseif ( '0' === $attempt_kbn ) {// Attempt kbn is normal.
 					$order->add_order_note( __( 'Using a card that is not 3D Secure.', 'woocommerce-for-paygent-payment-main' ) );
@@ -1218,9 +1235,7 @@ jQuery(function(){
 					$order->add_order_note( __( 'Attempt kbn is normal.', 'woocommerce-for-paygent-payment-main' ) );
 				} else {
 					$order->add_order_note( __( 'There was no response from Attempt kbn.', 'woocommerce-for-paygent-payment-main' ) );
-					wc_add_notice( __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-					wp_safe_redirect( wc_get_checkout_url() );
-					exit;
+					$this->paygent_tds2_failure_redirect( __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ) );
 				}
 				// If necessary, register customer's card information.
 				$user_wants_save_card = '1' === $order->get_meta( '_paygent_save_card_preference' );
@@ -1244,18 +1259,14 @@ jQuery(function(){
 				} else {
 					wc_increase_stock_levels( $order_id );
 					$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-					wc_add_notice( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-					wp_safe_redirect( wc_get_checkout_url() );
-					exit;
+					$this->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
 				}
 			} elseif ( '1' === $_GET['result'] ) {// phpcs:ignore
 				wc_increase_stock_levels( $order_id );
 				$response_code   = wc_clean( wp_unslash( $_GET['response_code'] ?? '' ) );// phpcs:ignore
 				$response_detail = wc_clean( wp_unslash( urldecode( $_GET['response_detail'] ?? '' ) ) );// phpcs:ignore
 				$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) . '[' . $response_code . ':' . $response_detail . ']' );
-				wc_add_notice( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-				wp_safe_redirect( wc_get_checkout_url() );
-				exit;
+				$this->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
 			}
 		} elseif ( $html && $order->get_payment_method() === $this->id ) {// First redirect to 3D Secure 2.0 Challenge flow.
 			$before = array( '<html>', '<body onload="OnLoadEvent();">', '</body>', '</html>' );
@@ -1294,13 +1305,10 @@ jQuery(function(){
 		if ( 'yes' === $this->no_tds_card ) {
 			wc_increase_stock_levels( $order->get_id() );
 			$order->update_status( 'cancelled', __( 'No 3D Secure 2.0 card.', 'woocommerce-for-paygent-payment-main' ) );
-			wc_add_notice(
+			$this->paygent_tds2_failure_redirect(
 				__( 'This payment uses a card that does not have 3D Secure.', 'woocommerce-for-paygent-payment-main' )
-				. ' ' . __( 'Please use a card that supports 3D Secure.', 'woocommerce-for-paygent-payment-main' ),
-				'error'
+				. ' ' . __( 'Please use a card that supports 3D Secure.', 'woocommerce-for-paygent-payment-main' )
 			);
-			wp_safe_redirect( wc_get_checkout_url() );
-			exit;
 		}
 	}
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-cc.php
@@ -1172,15 +1172,19 @@ jQuery(function(){
 	 * checkout: this runs on the order-pay page the ACS redirects back to,
 	 * a separate full-page load from any Store API request, so Block
 	 * Checkout never surfaces it (Store API discards session notices that
-	 * aren't raised during its own request/response cycle). The message is
-	 * therefore also passed via the redirect URL so the checkout page can
-	 * display it client-side regardless of which checkout is active.
+	 * aren't raised during its own request/response cycle). The failure is
+	 * therefore also passed via the redirect URL — as the opaque `$code`,
+	 * never the message text — so the checkout page can look up and display
+	 * the matching whitelisted string client-side (see
+	 * `WC_Gateway_Paygent::get_3ds2_failure_messages()`) regardless of which
+	 * checkout is active, without letting the URL dictate arbitrary text.
 	 *
-	 * @param string $message Error message to show the customer.
+	 * @param string $code Key into WC_Gateway_Paygent::get_3ds2_failure_messages().
 	 */
-	public function paygent_tds2_failure_redirect( $message ) {
-		wc_add_notice( $message, 'error' );
-		wp_safe_redirect( add_query_arg( 'paygent_3ds2_error', rawurlencode( $message ), wc_get_checkout_url() ) );
+	public function paygent_tds2_failure_redirect( $code ) {
+		$messages = WC_Gateway_Paygent::get_3ds2_failure_messages();
+		wc_add_notice( $messages[ $code ] ?? $messages['auth_failed'], 'error' );
+		wp_safe_redirect( add_query_arg( 'paygent_3ds2_error', $code, wc_get_checkout_url() ) );
 		exit;
 	}
 
@@ -1226,7 +1230,7 @@ jQuery(function(){
 					if ( 'yes' !== $this->attempt ) {
 						wc_increase_stock_levels( $order_id );
 						$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-						$this->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
+						$this->paygent_tds2_failure_redirect( 'auth_failed' );
 					}
 				} elseif ( '0' === $attempt_kbn ) {// Attempt kbn is normal.
 					$order->add_order_note( __( 'Using a card that is not 3D Secure.', 'woocommerce-for-paygent-payment-main' ) );
@@ -1235,7 +1239,7 @@ jQuery(function(){
 					$order->add_order_note( __( 'Attempt kbn is normal.', 'woocommerce-for-paygent-payment-main' ) );
 				} else {
 					$order->add_order_note( __( 'There was no response from Attempt kbn.', 'woocommerce-for-paygent-payment-main' ) );
-					$this->paygent_tds2_failure_redirect( __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ) );
+					$this->paygent_tds2_failure_redirect( 'attempt_unknown' );
 				}
 				// If necessary, register customer's card information.
 				$user_wants_save_card = '1' === $order->get_meta( '_paygent_save_card_preference' );
@@ -1259,14 +1263,14 @@ jQuery(function(){
 				} else {
 					wc_increase_stock_levels( $order_id );
 					$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-					$this->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
+					$this->paygent_tds2_failure_redirect( 'auth_failed' );
 				}
 			} elseif ( '1' === $_GET['result'] ) {// phpcs:ignore
 				wc_increase_stock_levels( $order_id );
 				$response_code   = wc_clean( wp_unslash( $_GET['response_code'] ?? '' ) );// phpcs:ignore
 				$response_detail = wc_clean( wp_unslash( urldecode( $_GET['response_detail'] ?? '' ) ) );// phpcs:ignore
 				$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) . '[' . $response_code . ':' . $response_detail . ']' );
-				$this->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
+				$this->paygent_tds2_failure_redirect( 'auth_failed' );
 			}
 		} elseif ( $html && $order->get_payment_method() === $this->id ) {// First redirect to 3D Secure 2.0 Challenge flow.
 			$before = array( '<html>', '<body onload="OnLoadEvent();">', '</body>', '</html>' );
@@ -1305,10 +1309,7 @@ jQuery(function(){
 		if ( 'yes' === $this->no_tds_card ) {
 			wc_increase_stock_levels( $order->get_id() );
 			$order->update_status( 'cancelled', __( 'No 3D Secure 2.0 card.', 'woocommerce-for-paygent-payment-main' ) );
-			$this->paygent_tds2_failure_redirect(
-				__( 'This payment uses a card that does not have 3D Secure.', 'woocommerce-for-paygent-payment-main' )
-				. ' ' . __( 'Please use a card that supports 3D Secure.', 'woocommerce-for-paygent-payment-main' )
-			);
+			$this->paygent_tds2_failure_redirect( 'no_3ds_card' );
 		}
 	}
 

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -620,9 +620,7 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 					if ( 'yes' !== $this->attempt ) {
 						wc_increase_stock_levels( $order_id );
 						$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-						wc_add_notice( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-						wp_safe_redirect( wc_get_checkout_url() );
-						exit;
+						$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
 					}
 				} elseif ( '0' === $attempt_kbn ) {// Attempt kbn is normal.
 					$order->add_order_note( __( 'Using a card that is not 3D Secure.', 'woocommerce-for-paygent-payment-main' ) );
@@ -632,9 +630,7 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 					$order->add_order_note( __( 'Attempt kbn is normal.', 'woocommerce-for-paygent-payment-main' ) );
 				} else {
 					$order->add_order_note( __( 'There was no response from Attempt kbn.', 'woocommerce-for-paygent-payment-main' ) );
-					wc_add_notice( __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-					wp_safe_redirect( wc_get_checkout_url() );
-					exit;
+					$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ) );
 				}
 				// If necessary, register customer's card information.
 				$user_wants_save_card = '1' === $order->get_meta( '_paygent_save_card_preference' );
@@ -658,18 +654,14 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 				} else {
 					wc_increase_stock_levels( $order_id );
 					$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-					wc_add_notice( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-					wp_safe_redirect( wc_get_checkout_url() );
-					exit;
+					$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
 				}
 			} elseif ( '1' === $_GET['result'] ) {// phpcs:ignore
 				wc_increase_stock_levels( $order_id );
 				$response_code   = wc_clean( wp_unslash( $_GET['response_code'] ?? '' ) );// phpcs:ignore
 				$response_detail = wc_clean( wp_unslash( urldecode( $_GET['response_detail'] ?? '' ) ) );// phpcs:ignore
 				$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) . '[' . $response_code . ':' . $response_detail . ']' );
-				wc_add_notice( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ), 'error' );
-				wp_safe_redirect( wc_get_checkout_url() );
-				exit;
+				$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
 			}
 		} elseif ( $html && $order->get_payment_method() === $this->id ) {// First redirect to 3D Secure 2.0 Challenge flow.
 			$before = array( '<html>', '<body onload="OnLoadEvent();">', '</body>', '</html>' );

--- a/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
+++ b/includes/gateways/paygent/class-wc-gateway-paygent-mccc.php
@@ -620,7 +620,7 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 					if ( 'yes' !== $this->attempt ) {
 						wc_increase_stock_levels( $order_id );
 						$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-						$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
+						$this->paygent_cc->paygent_tds2_failure_redirect( 'auth_failed' );
 					}
 				} elseif ( '0' === $attempt_kbn ) {// Attempt kbn is normal.
 					$order->add_order_note( __( 'Using a card that is not 3D Secure.', 'woocommerce-for-paygent-payment-main' ) );
@@ -630,7 +630,7 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 					$order->add_order_note( __( 'Attempt kbn is normal.', 'woocommerce-for-paygent-payment-main' ) );
 				} else {
 					$order->add_order_note( __( 'There was no response from Attempt kbn.', 'woocommerce-for-paygent-payment-main' ) );
-					$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Attempt kbn was not answered. Something seems to be wrong. Please try a different card or contact the site administrator.', 'woocommerce-for-paygent-payment-main' ) );
+					$this->paygent_cc->paygent_tds2_failure_redirect( 'attempt_unknown' );
 				}
 				// If necessary, register customer's card information.
 				$user_wants_save_card = '1' === $order->get_meta( '_paygent_save_card_preference' );
@@ -654,14 +654,14 @@ class WC_Gateway_Paygent_MCCC extends WC_Payment_Gateway {
 				} else {
 					wc_increase_stock_levels( $order_id );
 					$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) );
-					$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
+					$this->paygent_cc->paygent_tds2_failure_redirect( 'auth_failed' );
 				}
 			} elseif ( '1' === $_GET['result'] ) {// phpcs:ignore
 				wc_increase_stock_levels( $order_id );
 				$response_code   = wc_clean( wp_unslash( $_GET['response_code'] ?? '' ) );// phpcs:ignore
 				$response_detail = wc_clean( wp_unslash( urldecode( $_GET['response_detail'] ?? '' ) ) );// phpcs:ignore
 				$order->update_status( 'cancelled', __( 'Failed 3D Secure 2.0.', 'woocommerce-for-paygent-payment-main' ) . '[' . $response_code . ':' . $response_detail . ']' );
-				$this->paygent_cc->paygent_tds2_failure_redirect( __( 'Authentication was not obtained for credit card payment.', 'woocommerce-for-paygent-payment-main' ) );
+				$this->paygent_cc->paygent_tds2_failure_redirect( 'auth_failed' );
 			}
 		} elseif ( $html && $order->get_payment_method() === $this->id ) {// First redirect to 3D Secure 2.0 Challenge flow.
 			$before = array( '<html>', '<body onload="OnLoadEvent();">', '</body>', '</html>' );

--- a/package-lock.json
+++ b/package-lock.json
@@ -32,13 +32,13 @@
 			}
 		},
 		"node_modules/@babel/code-frame": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-			"integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+			"integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.28.5",
+				"@babel/helper-validator-identifier": "^7.29.7",
 				"js-tokens": "^4.0.0",
 				"picocolors": "^1.1.1"
 			},
@@ -107,14 +107,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.29.1",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-			"integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+			"integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.29.0",
-				"@babel/types": "^7.29.0",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"@jridgewell/gen-mapping": "^0.3.12",
 				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
@@ -211,9 +211,9 @@
 			}
 		},
 		"node_modules/@babel/helper-globals": {
-			"version": "7.28.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-			"integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+			"integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -235,29 +235,29 @@
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-			"integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+			"integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/traverse": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/traverse": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-			"integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+			"integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-imports": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.28.6"
+				"@babel/helper-module-imports": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -280,9 +280,9 @@
 			}
 		},
 		"node_modules/@babel/helper-plugin-utils": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.28.6.tgz",
-			"integrity": "sha512-S9gzZ/bz83GRysI7gAD4wPT/AI3uCnY+9xn+Mx/KPs2JwHJIz1W8PZkg2cqyt3RNOBM8ejcXhV6y8Og7ly/Dug==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+			"integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -340,9 +340,9 @@
 			}
 		},
 		"node_modules/@babel/helper-string-parser": {
-			"version": "7.27.1",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-			"integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+			"integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -350,9 +350,9 @@
 			}
 		},
 		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.28.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-			"integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+			"integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -399,13 +399,13 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.29.2",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-			"integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+			"integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.29.0"
+				"@babel/types": "^7.29.7"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1205,16 +1205,16 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-modules-systemjs": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-			"integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.7.tgz",
+			"integrity": "sha512-TM2ZcQLoG2/y4HODiStCo10DibYhWhGWAwVv+EQKmG/7GFl0N+AAmUiXOMKM+aiJ9XBJ9AHVZBvTzMnJ2sM3cQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-module-transforms": "^7.28.6",
-				"@babel/helper-plugin-utils": "^7.28.6",
-				"@babel/helper-validator-identifier": "^7.28.5",
-				"@babel/traverse": "^7.29.0"
+				"@babel/helper-module-transforms": "^7.29.7",
+				"@babel/helper-plugin-utils": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7",
+				"@babel/traverse": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1921,33 +1921,33 @@
 			}
 		},
 		"node_modules/@babel/template": {
-			"version": "7.28.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-			"integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+			"integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.28.6",
-				"@babel/parser": "^7.28.6",
-				"@babel/types": "^7.28.6"
+				"@babel/code-frame": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/types": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-			"integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+			"integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/code-frame": "^7.29.0",
-				"@babel/generator": "^7.29.0",
-				"@babel/helper-globals": "^7.28.0",
-				"@babel/parser": "^7.29.0",
-				"@babel/template": "^7.28.6",
-				"@babel/types": "^7.29.0",
+				"@babel/code-frame": "^7.29.7",
+				"@babel/generator": "^7.29.7",
+				"@babel/helper-globals": "^7.29.7",
+				"@babel/parser": "^7.29.7",
+				"@babel/template": "^7.29.7",
+				"@babel/types": "^7.29.7",
 				"debug": "^4.3.1"
 			},
 			"engines": {
@@ -1955,14 +1955,14 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.29.0",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-			"integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+			"version": "7.29.7",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+			"integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/helper-string-parser": "^7.27.1",
-				"@babel/helper-validator-identifier": "^7.28.5"
+				"@babel/helper-string-parser": "^7.29.7",
+				"@babel/helper-validator-identifier": "^7.29.7"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -2272,9 +2272,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -2283,10 +2283,20 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -2445,9 +2455,9 @@
 			}
 		},
 		"node_modules/@humanwhocodes/config-array/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3445,9 +3455,9 @@
 			}
 		},
 		"node_modules/@nodable/entities": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
-			"integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-3.0.0.tgz",
+			"integrity": "sha512-8L9xFeTYKhm49xfIypoe2W5wV1m/3Z58kT+7kR9A8OyFxcPduI4VmxaUMQyKYrRjUoLLSXv6EKKID5Tvj9cUVw==",
 			"dev": true,
 			"funding": [
 				{
@@ -5001,14 +5011,14 @@
 			}
 		},
 		"node_modules/@php-wasm/cli-util": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.26.tgz",
-			"integrity": "sha512-ROnL0vAb/hUth/nm+iKctlzIVKGMkXodW3G0Vnv5HCwA1Nyhj7hiCmn/9eR+lGRFcJfDc7akjVm6CmyA1lGcsw==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/cli-util/-/cli-util-3.1.46.tgz",
+			"integrity": "sha512-m3bDR/PyiiJzdRMwUBfbXG2VwB+OhrAcCAmLbjB3dkkPxJ7mSCnNbInDY43fkpUuiqTCzamrrgt/tpGdtLPTiQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/util": "3.1.26",
-				"fast-xml-parser": "^5.5.1",
+				"@php-wasm/util": "3.1.46",
+				"fast-xml-parser": "^5.8.0",
 				"jsonc-parser": "3.3.1"
 			},
 			"engines": {
@@ -5024,9 +5034,9 @@
 			"license": "MIT"
 		},
 		"node_modules/@php-wasm/logger": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.26.tgz",
-			"integrity": "sha512-zMswdzK4SMakSJGoKLITGLGmmo4DfX7Q6qri+1QjEJsFf0RWAlBj7uu9oB+SJpF5b8FBBB53N6n/hRaA8DPYJw==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/logger/-/logger-3.1.46.tgz",
+			"integrity": "sha512-PfnDq5ammh5FXxkGX1TGEck9gmW3i76IvBCqtX4D45xnSBIuCeu8uf2oWuty2j/c8wTEO8vyRDdvCj5oow7bXw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5035,34 +5045,27 @@
 			}
 		},
 		"node_modules/@php-wasm/node": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.26.tgz",
-			"integrity": "sha512-Q7AKyt9Y+9XaUxJCvG4TGwQThYY2D+9FxjyCRLH8us9f0fbr/ZQA8cUCU2YM2CTlWLdJrT01Z/dnxEqOCdC6Ww==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node/-/node-3.1.46.tgz",
+			"integrity": "sha512-PHmV+nAQka6l4SB7GyAbkneqnyhTvfjhC9jArKNF7sUDGwVDdvvu0Fh5JRY4G1Eam3Z5gopD4YwDySJCfdq8LA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.26",
-				"@php-wasm/logger": "3.1.26",
-				"@php-wasm/node-5-2": "3.1.26",
-				"@php-wasm/node-7-4": "3.1.26",
-				"@php-wasm/node-8-0": "3.1.26",
-				"@php-wasm/node-8-1": "3.1.26",
-				"@php-wasm/node-8-2": "3.1.26",
-				"@php-wasm/node-8-3": "3.1.26",
-				"@php-wasm/node-8-4": "3.1.26",
-				"@php-wasm/node-8-5": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"@php-wasm/util": "3.1.26",
-				"@wp-playground/common": "3.1.26",
-				"ajv": "8.12.0",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
+				"@php-wasm/cli-util": "3.1.46",
+				"@php-wasm/logger": "3.1.46",
+				"@php-wasm/node-5-2": "3.1.46",
+				"@php-wasm/node-7-4": "3.1.46",
+				"@php-wasm/node-8-0": "3.1.46",
+				"@php-wasm/node-8-1": "3.1.46",
+				"@php-wasm/node-8-2": "3.1.46",
+				"@php-wasm/node-8-3": "3.1.46",
+				"@php-wasm/node-8-4": "3.1.46",
+				"@php-wasm/node-8-5": "3.1.46",
+				"@php-wasm/universal": "3.1.46",
+				"@php-wasm/util": "3.1.46",
 				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
 				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0",
-				"yargs": "17.7.2"
+				"ws": "8.21.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -5070,732 +5073,133 @@
 			}
 		},
 		"node_modules/@php-wasm/node-5-2": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.26.tgz",
-			"integrity": "sha512-Q+njtzwY7NrvT2N0JmNRV0JMBVG3L6SomkQFBZy7BSk6qPqsK889LhVmSvoElXP3vXfB6oqO9g8ALX3CKez9zw==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-5-2/-/node-5-2-3.1.46.tgz",
+			"integrity": "sha512-J77WzhYO0cBPDktaoBZ7y980knhN4/nghhVjv7fj57fWYA1m5ZbCGOqcZUys7sQm/vdahcpaU27vqUCHXBrbZw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-5-2/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-5-2/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-5-2/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-5-2/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-7-4": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.26.tgz",
-			"integrity": "sha512-VLiLnpWHCN4eQnnoTk7h0u1qCWJUV/8J7TaEqDtfR1OKR+L1L1W2bPzUNm5L4u5D14a8yrMdM362LNiaxer4mg==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-7-4/-/node-7-4-3.1.46.tgz",
+			"integrity": "sha512-HC3li/qX49C5FJKff0X+uewMFzVI5IE2hBhTb0DsJGn5xME1F7W6WoZ4hjrKkIGkjIbATPmiDGspUoHrvmX83A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-7-4/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-7-4/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-7-4/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-7-4/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-8-0": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.26.tgz",
-			"integrity": "sha512-Ssl/X9Y1KvRowT9cmdb+yh6Fc+k8fZk9wiKqC2eImflK1Gjweg56YQPb/z7Gag1vWPYdck0TmC8WblPA+tIv2A==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-0/-/node-8-0-3.1.46.tgz",
+			"integrity": "sha512-insUfErssn1NpQ3DNpRYOgTRf89/R7j2b7svMOU05J2sb6v3UFSmkKIR8MndxgvgW5uQhvyQyGHVa79B93ykiA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-0/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-8-0/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-0/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-8-0/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-8-1": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.26.tgz",
-			"integrity": "sha512-FCe1PhNrRq8lRH3klam6JXmD9YKxBIgcsf+CGOXzrPW/MYiZhyACK0em1FlDyfFbc2w26whhu0TqRacuJSZUjA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-1/-/node-8-1-3.1.46.tgz",
+			"integrity": "sha512-nPvpbUqAwHmrUSbaLFHgUZDuvyAfo1OfMjLXdgqMjn5nb2QnjlKota4afA/2F6j2WxzjdiXZxro1bSa5fB+OlQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-1/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-8-1/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-1/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-8-1/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-8-2": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.26.tgz",
-			"integrity": "sha512-HndHQtelVjPMVXf7NuNVwPcCm4DTWArXBFP3qK7eZ/ooG/N9inALfL5uSYnRFiWAYW+bZ+6l8/a8j/+kq6BYfA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-2/-/node-8-2-3.1.46.tgz",
+			"integrity": "sha512-CyDiEZjDBQMsrEnNN+1ZOXcgB4K5bYZ8lmYYDdmGnto7U4nAyzPOT+LydkRoLd27AqabJqnimwkryduDptbE/A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-2/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-8-2/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-2/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-8-2/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-8-3": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.26.tgz",
-			"integrity": "sha512-CyKnXJa47Y8CvNqBgr7m9m4gqoRvFrO2rgvRns6icEigZObU+qkYwjKUUH6LmDRbQU5mzhUpbhLcSe15+edy3Q==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-3/-/node-8-3-3.1.46.tgz",
+			"integrity": "sha512-ZSH1rPvVuhIYJkGE/GRkQtv7RoQlO0IMWkHLJGt+JrTeaDxxm8Mv/F0H67MrA80q43zzNdNQaUEPn+ZrN/GSwg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-3/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-8-3/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-3/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-8-3/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-8-4": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.26.tgz",
-			"integrity": "sha512-Bp4SoG2bFGDD4MOmmCg7r2xOHmceo/zoJj0P+8Cgll8Na+NVTnrNdWC4cvFh9ZaFVh/Lx8+3FaPPfRknG7iudQ==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-4/-/node-8-4-3.1.46.tgz",
+			"integrity": "sha512-4Wl7hwp6p3m0jaliIMYJz8cIY7obJF3HKxoHKxOcVllKgP+cSr5c/iwFcgYct4goC9sP7wr/xQGeClGQ51aP0A==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/node-8-4/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-8-4/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-4/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-8-4/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@php-wasm/node-8-5": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.26.tgz",
-			"integrity": "sha512-rbp9UTiBrVhcec9yZ+axWArFf/L/KBB4rUTHP0d1QYwFxeOfGv9UCowMt5eHcdsB8J66zgtc9iWk8GacGPqlGA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/node-8-5/-/node-8-5-3.1.46.tgz",
+			"integrity": "sha512-ndL2jnGCVVwhAmHPgo3tWZ+I6q2Flz6OWbbQwGVBQcXqqPdZuVHh+0Gb5KTTn1cGtCErdpL+3ysLwN7tk5LqUA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0"
+				"@php-wasm/universal": "3.1.46",
+				"wasm-feature-detect": "1.8.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/node-8-5/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node-8-5/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node-8-5/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node-8-5/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/node/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node/node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/node/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@php-wasm/progress": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.26.tgz",
-			"integrity": "sha512-UTgXFK0/Y3ybCkG3SuuU1o4jD1SyhBVqGHcF40xrmHAyEvvHX4affIhqFeAga5ajWDwZFg5aDaapN+2q+0P0Mg==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/progress/-/progress-3.1.46.tgz",
+			"integrity": "sha512-WmmgEm6yz322M3pzgAUjxckyhpVxr2WWlHyVYDyaMZWU6UIDUHfiRZRPzADohNyYvV3g0/zMNaDGmxz+TTXwQQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.26"
+				"@php-wasm/logger": "3.1.46"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -5803,9 +5207,9 @@
 			}
 		},
 		"node_modules/@php-wasm/scopes": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.26.tgz",
-			"integrity": "sha512-c5sRt36anv5WEChVlyWb3jPTj/TZE5dlOOBXw6zGVe4ZJdfun0APQee9W4yL6kpoLf3iGQL9JVl2z3Sd0CNYbA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/scopes/-/scopes-3.1.46.tgz",
+			"integrity": "sha512-WkH55sjdRSE+FIljMy97ScPIhGLbdVZOSmwXJkctEvmflZqtDIS4fOs9qRKj2dV+Nh4ewyfcWUSf5tTMJnyAuA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -5814,49 +5218,31 @@
 			}
 		},
 		"node_modules/@php-wasm/stream-compression": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.26.tgz",
-			"integrity": "sha512-eWqRZXtVrcXcrkakJoWAO2VXRq+JJ+CRphT95Qn99StqZdU6VhlgsYraBwrhAJrtSCRXUMIk33x7CwqKPU9Qew==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/stream-compression/-/stream-compression-3.1.46.tgz",
+			"integrity": "sha512-+oUw4CPX52FgYXEh5C+MgJAg7Cy5OeaVuh7HnQR6oxb69nU63/r8tHTLV/WrWRyjBYh321uJzLV7Gg29qmiUtg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/util": "3.1.26"
+				"@php-wasm/util": "3.1.46"
 			}
 		},
 		"node_modules/@php-wasm/universal": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.26.tgz",
-			"integrity": "sha512-ZtA8P/XNmDpmCIbK4Pqo2nWICVrD6C12fcx42zuAh2E2NMEeXLtZnOUIEEBBI8ZcoV1t7LIlScVuOXV/0+iOiw==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/universal/-/universal-3.1.46.tgz",
+			"integrity": "sha512-sx0KyN5kcsCMzwy+XJAyoOukSA5TEZYd0LK3l9kRP3I0CSd5h6JItkf5eZ42WltB+wD+aTRdqSwc/Mvkc7qBjQ==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.26",
-				"@php-wasm/progress": "3.1.26",
-				"@php-wasm/stream-compression": "3.1.26",
-				"@php-wasm/util": "3.1.26",
-				"ajv": "8.12.0",
+				"@php-wasm/logger": "3.1.46",
+				"@php-wasm/progress": "3.1.46",
+				"@php-wasm/stream-compression": "3.1.46",
+				"@php-wasm/util": "3.1.46",
 				"ini": "4.1.2"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/universal/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
 			}
 		},
 		"node_modules/@php-wasm/universal/node_modules/ini": {
@@ -5869,17 +5255,10 @@
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@php-wasm/universal/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@php-wasm/util": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.26.tgz",
-			"integrity": "sha512-z7yuMiz2PDeozKfzO0KacXDGKUJA1pA+/8QPeddNuIUekJh4UYDhVfMrySZXjmN3iKupvK1DxWt73a1GDpyFvA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/util/-/util-3.1.46.tgz",
+			"integrity": "sha512-Yh9HNbx+rB2R1tScUvvAsbJVIB7msjWceWYogyR2YvAOqlDL0ymZyaQ65+K3QcHh/8HostTRwwgQh5oK4DLDrA==",
 			"dev": true,
 			"engines": {
 				"node": ">=20.10.0",
@@ -5887,75 +5266,30 @@
 			}
 		},
 		"node_modules/@php-wasm/web-service-worker": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.26.tgz",
-			"integrity": "sha512-NBcqgRbjguU9mhDvI2luVcwd4yxMHChUXimItyDb8Es5rwmkS9YyJKIP6Q2XJu3m5n6ZAwtlW2x5OIEW84wmlg==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/web-service-worker/-/web-service-worker-3.1.46.tgz",
+			"integrity": "sha512-GwQzZbEnF+7a3wGqDaMCdbsCuDUdOvTyHAul40TbSATUZ1FdUVagI94pMMMQtYCCxQFnEuO/WxzwDKJJ3hpaug==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/scopes": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2"
+				"@php-wasm/scopes": "3.1.46",
+				"@php-wasm/universal": "3.1.46"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@php-wasm/web-service-worker/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/web-service-worker/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/web-service-worker/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@php-wasm/xdebug-bridge": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.26.tgz",
-			"integrity": "sha512-GBLqoS2Ohj9/51Nfi1gluMo51RUYIY713EmAwSQzYMNgOSvftHrREK+ZBmzO1mROWJypTt1j7qfXv6Px62Uwqw==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@php-wasm/xdebug-bridge/-/xdebug-bridge-3.1.46.tgz",
+			"integrity": "sha512-no8Hr5Uw6EcwKjwUbBHlu2gTCZ5v4szeQT1AKjDYazM8Mur1AtaL2/q8X0IB8Hy4NDV/Jxgt33lxCh1n8XnnWA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.26",
-				"@php-wasm/node": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"@wp-playground/common": "3.1.26",
-				"ajv": "8.12.0",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0",
+				"@php-wasm/logger": "3.1.46",
+				"@php-wasm/universal": "3.1.46",
+				"ws": "8.21.0",
 				"xml2js": "0.6.2",
 				"yargs": "17.7.2"
 			},
@@ -5965,133 +5299,6 @@
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@php-wasm/xdebug-bridge/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@pkgjs/parseargs": {
@@ -6719,9 +5926,9 @@
 			}
 		},
 		"node_modules/@tootallnate/once": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
-			"integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.1.tgz",
+			"integrity": "sha512-HqmEUIGRJ5fSXchkVgR5F7qn48bDBzv0kWj/Kfu5e6uci4UlEeng4331LnBkWffb++Ei3FOVLxo8JJWMFBDMeQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -6747,9 +5954,9 @@
 			}
 		},
 		"node_modules/@types/aws-lambda": {
-			"version": "8.10.161",
-			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.161.tgz",
-			"integrity": "sha512-rUYdp+MQwSFocxIOcSsYSF3YYYC/uUpMbCY/mbO21vGqfrEYvNSoPyKYDj6RhXXpPfS0KstW9RwG3qXh9sL7FQ==",
+			"version": "8.10.162",
+			"resolved": "https://registry.npmjs.org/@types/aws-lambda/-/aws-lambda-8.10.162.tgz",
+			"integrity": "sha512-Fn658grtLOci1oxi1391vvDWJRKNGWRSqfxRkmN/Iy3c0tQH1USMKEXcPYHLvope+ZgTFocx9FRQJx1muBL6qw==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8056,221 +7263,27 @@
 			}
 		},
 		"node_modules/@wordpress/babel-preset-default": {
-			"version": "8.44.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.44.0.tgz",
-			"integrity": "sha512-6EQW8ysiQkct2MolHlhyqXfZ/Vgl0Cu9dCeHfPEf7S/8575qua1GnuDSFzEqU/8TIrEG88f2e2qP/R7VRB+EwQ==",
+			"version": "8.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/babel-preset-default/-/babel-preset-default-8.51.0.tgz",
+			"integrity": "sha512-blv2dA2gH9XzD71jiX5rI68Xjioais+n4UC8+wSVcGmHzcVuOHta/serOD8nYzQL0+HOv59O29uzXGONKDWzNg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@babel/core": "7.25.7",
-				"@babel/plugin-syntax-import-attributes": "7.26.0",
-				"@babel/plugin-transform-react-jsx": "7.25.7",
-				"@babel/plugin-transform-runtime": "7.25.7",
-				"@babel/preset-env": "7.25.7",
-				"@babel/preset-typescript": "7.25.7",
-				"@wordpress/browserslist-config": "^6.44.0",
-				"@wordpress/warning": "^3.44.0",
-				"browserslist": "^4.21.10",
+				"@babel/core": "^7.25.7",
+				"@babel/plugin-syntax-import-attributes": "^7.26.0",
+				"@babel/plugin-transform-react-jsx": "^7.25.7",
+				"@babel/plugin-transform-runtime": "^7.25.7",
+				"@babel/preset-env": "^7.25.7",
+				"@babel/preset-typescript": "^7.25.7",
+				"@wordpress/browserslist-config": "^6.51.0",
+				"@wordpress/warning": "^3.51.0",
+				"browserslist": "^4.28.4",
 				"core-js": "^3.31.0",
-				"react": "^18.3.0"
+				"react": "^18.3.1"
 			},
 			"engines": {
 				"node": ">=18.12.0",
 				"npm": ">=8.19.2"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/plugin-syntax-import-attributes": {
-			"version": "7.26.0",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-import-attributes/-/plugin-syntax-import-attributes-7.26.0.tgz",
-			"integrity": "sha512-e2dttdsJ1ZTpi3B9UYGLw41hifAubg19AtCu/2I/F1QNVclOBr1dYpTdmdyZ84Xiz43BS/tCUkMAZNLv12Pi+A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/plugin-transform-react-jsx": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
-			"integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-annotate-as-pure": "^7.25.7",
-				"@babel/helper-module-imports": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/plugin-syntax-jsx": "^7.25.7",
-				"@babel/types": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-env": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.25.7.tgz",
-			"integrity": "sha512-Gibz4OUdyNqqLj+7OAvBZxOD7CklCtMA5/j0JgUEwOnaRULsPDXmic2iKxL2DX2vQduPR5wH2hjZas/Vr/Oc0g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/compat-data": "^7.25.7",
-				"@babel/helper-compilation-targets": "^7.25.7",
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-validator-option": "^7.25.7",
-				"@babel/plugin-bugfix-firefox-class-in-computed-class-key": "^7.25.7",
-				"@babel/plugin-bugfix-safari-class-field-initializer-scope": "^7.25.7",
-				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.25.7",
-				"@babel/plugin-bugfix-v8-spread-parameters-in-optional-chaining": "^7.25.7",
-				"@babel/plugin-bugfix-v8-static-class-fields-redefine-readonly": "^7.25.7",
-				"@babel/plugin-proposal-private-property-in-object": "7.21.0-placeholder-for-preset-env.2",
-				"@babel/plugin-syntax-async-generators": "^7.8.4",
-				"@babel/plugin-syntax-class-properties": "^7.12.13",
-				"@babel/plugin-syntax-class-static-block": "^7.14.5",
-				"@babel/plugin-syntax-dynamic-import": "^7.8.3",
-				"@babel/plugin-syntax-export-namespace-from": "^7.8.3",
-				"@babel/plugin-syntax-import-assertions": "^7.25.7",
-				"@babel/plugin-syntax-import-attributes": "^7.25.7",
-				"@babel/plugin-syntax-import-meta": "^7.10.4",
-				"@babel/plugin-syntax-json-strings": "^7.8.3",
-				"@babel/plugin-syntax-logical-assignment-operators": "^7.10.4",
-				"@babel/plugin-syntax-nullish-coalescing-operator": "^7.8.3",
-				"@babel/plugin-syntax-numeric-separator": "^7.10.4",
-				"@babel/plugin-syntax-object-rest-spread": "^7.8.3",
-				"@babel/plugin-syntax-optional-catch-binding": "^7.8.3",
-				"@babel/plugin-syntax-optional-chaining": "^7.8.3",
-				"@babel/plugin-syntax-private-property-in-object": "^7.14.5",
-				"@babel/plugin-syntax-top-level-await": "^7.14.5",
-				"@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
-				"@babel/plugin-transform-arrow-functions": "^7.25.7",
-				"@babel/plugin-transform-async-generator-functions": "^7.25.7",
-				"@babel/plugin-transform-async-to-generator": "^7.25.7",
-				"@babel/plugin-transform-block-scoped-functions": "^7.25.7",
-				"@babel/plugin-transform-block-scoping": "^7.25.7",
-				"@babel/plugin-transform-class-properties": "^7.25.7",
-				"@babel/plugin-transform-class-static-block": "^7.25.7",
-				"@babel/plugin-transform-classes": "^7.25.7",
-				"@babel/plugin-transform-computed-properties": "^7.25.7",
-				"@babel/plugin-transform-destructuring": "^7.25.7",
-				"@babel/plugin-transform-dotall-regex": "^7.25.7",
-				"@babel/plugin-transform-duplicate-keys": "^7.25.7",
-				"@babel/plugin-transform-duplicate-named-capturing-groups-regex": "^7.25.7",
-				"@babel/plugin-transform-dynamic-import": "^7.25.7",
-				"@babel/plugin-transform-exponentiation-operator": "^7.25.7",
-				"@babel/plugin-transform-export-namespace-from": "^7.25.7",
-				"@babel/plugin-transform-for-of": "^7.25.7",
-				"@babel/plugin-transform-function-name": "^7.25.7",
-				"@babel/plugin-transform-json-strings": "^7.25.7",
-				"@babel/plugin-transform-literals": "^7.25.7",
-				"@babel/plugin-transform-logical-assignment-operators": "^7.25.7",
-				"@babel/plugin-transform-member-expression-literals": "^7.25.7",
-				"@babel/plugin-transform-modules-amd": "^7.25.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.7",
-				"@babel/plugin-transform-modules-systemjs": "^7.25.7",
-				"@babel/plugin-transform-modules-umd": "^7.25.7",
-				"@babel/plugin-transform-named-capturing-groups-regex": "^7.25.7",
-				"@babel/plugin-transform-new-target": "^7.25.7",
-				"@babel/plugin-transform-nullish-coalescing-operator": "^7.25.7",
-				"@babel/plugin-transform-numeric-separator": "^7.25.7",
-				"@babel/plugin-transform-object-rest-spread": "^7.25.7",
-				"@babel/plugin-transform-object-super": "^7.25.7",
-				"@babel/plugin-transform-optional-catch-binding": "^7.25.7",
-				"@babel/plugin-transform-optional-chaining": "^7.25.7",
-				"@babel/plugin-transform-parameters": "^7.25.7",
-				"@babel/plugin-transform-private-methods": "^7.25.7",
-				"@babel/plugin-transform-private-property-in-object": "^7.25.7",
-				"@babel/plugin-transform-property-literals": "^7.25.7",
-				"@babel/plugin-transform-regenerator": "^7.25.7",
-				"@babel/plugin-transform-reserved-words": "^7.25.7",
-				"@babel/plugin-transform-shorthand-properties": "^7.25.7",
-				"@babel/plugin-transform-spread": "^7.25.7",
-				"@babel/plugin-transform-sticky-regex": "^7.25.7",
-				"@babel/plugin-transform-template-literals": "^7.25.7",
-				"@babel/plugin-transform-typeof-symbol": "^7.25.7",
-				"@babel/plugin-transform-unicode-escapes": "^7.25.7",
-				"@babel/plugin-transform-unicode-property-regex": "^7.25.7",
-				"@babel/plugin-transform-unicode-regex": "^7.25.7",
-				"@babel/plugin-transform-unicode-sets-regex": "^7.25.7",
-				"@babel/preset-modules": "0.1.6-no-external-plugins",
-				"babel-plugin-polyfill-corejs2": "^0.4.10",
-				"babel-plugin-polyfill-corejs3": "^0.10.6",
-				"babel-plugin-polyfill-regenerator": "^0.6.1",
-				"core-js-compat": "^3.38.1",
-				"semver": "^6.3.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-env/node_modules/@babel/plugin-syntax-dynamic-import": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-dynamic-import/-/plugin-syntax-dynamic-import-7.8.3.tgz",
-			"integrity": "sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-env/node_modules/@babel/plugin-syntax-export-namespace-from": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-export-namespace-from/-/plugin-syntax-export-namespace-from-7.8.3.tgz",
-			"integrity": "sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.8.3"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-env/node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.10.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.10.6.tgz",
-			"integrity": "sha512-b37+KR2i/khY5sKmWNVQAnitvquQbNdWy6lJdsr0kmquCKEEUgMKK4SboVM3HtfnZilfjr4MMQ7vY58FVWDtIA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.6.2",
-				"core-js-compat": "^3.38.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
-			}
-		},
-		"node_modules/@wordpress/babel-preset-default/node_modules/@babel/preset-typescript": {
-			"version": "7.25.7",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.25.7.tgz",
-			"integrity": "sha512-rkkpaXJZOFN45Fb+Gki0c+KMIglk4+zZXOoMJuyEK8y8Kkc8Jd3BDmP7qPsz0zQMJj+UD7EprF+AqAXcILnexw==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.25.7",
-				"@babel/helper-validator-option": "^7.25.7",
-				"@babel/plugin-syntax-jsx": "^7.25.7",
-				"@babel/plugin-transform-modules-commonjs": "^7.25.7",
-				"@babel/plugin-transform-typescript": "^7.25.7"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0-0"
 			}
 		},
 		"node_modules/@wordpress/base-styles": {
@@ -8285,9 +7298,9 @@
 			}
 		},
 		"node_modules/@wordpress/browserslist-config": {
-			"version": "6.44.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.44.0.tgz",
-			"integrity": "sha512-lYtkO7U7ok9RfRBIHWvVWXhcOys6cQuLfwFr1bGuPTE6+LmVHmRyniMnImZlG8Jb3XE4pvH8gXT1ecXogpDI2Q==",
+			"version": "6.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/browserslist-config/-/browserslist-config-6.51.0.tgz",
+			"integrity": "sha512-/siYL1d2O/evfWkXIDuhIVfHHBYE0T8hiD4JD8xm6JGe9Z2zHikveVT/AvJZrIzUBJknEIADyFE+cXimk97GkA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8974,9 +7987,9 @@
 			}
 		},
 		"node_modules/@wordpress/warning": {
-			"version": "3.44.0",
-			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.44.0.tgz",
-			"integrity": "sha512-avxdbIYhDuUh2qi2oiq7KeqYOVv2RubqV8UI/Q7bctZSFSXJE8RQGSR/W2YjABeyWBIjlyX/U5lOxVs2PIfy/w==",
+			"version": "3.51.0",
+			"resolved": "https://registry.npmjs.org/@wordpress/warning/-/warning-3.51.0.tgz",
+			"integrity": "sha512-wWeM6pjAWbMhdNfgCaxi5yhLzomj6/trcIjGPi2Q4kaIuxUula8Ybq0ZPn5lYuc19ICkcGYcAnWNYz/4mYCHdA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"engines": {
@@ -8985,45 +7998,21 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.26.tgz",
-			"integrity": "sha512-/A9M/4fzdmorXWBK2CcLTq06dn21EGHiQ5zPw4HsC1Koj2dYn+cUSWaZItdfh9/1d1cfIWvfWEjJs36h67QXow==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@wp-playground/blueprints/-/blueprints-3.1.46.tgz",
+			"integrity": "sha512-3X6AtHU8FyK4XtQKBN6lS3HKWykLl9TQ+t+iM3c6XYtQJatENoKmsZjv/JFgKEo6c+JP4ma8CsEdb6PqwJYEuw==",
 			"dev": true,
 			"dependencies": {
-				"@php-wasm/logger": "3.1.26",
-				"@php-wasm/node": "3.1.26",
-				"@php-wasm/progress": "3.1.26",
-				"@php-wasm/scopes": "3.1.26",
-				"@php-wasm/stream-compression": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"@php-wasm/util": "3.1.26",
-				"@php-wasm/web-service-worker": "3.1.26",
-				"@wp-playground/common": "3.1.26",
-				"@wp-playground/storage": "3.1.26",
-				"@wp-playground/wordpress": "3.1.26",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"playwright": "1.55.1",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0",
-				"yargs": "17.7.2"
+				"@php-wasm/logger": "3.1.46",
+				"@php-wasm/progress": "3.1.46",
+				"@php-wasm/stream-compression": "3.1.46",
+				"@php-wasm/universal": "3.1.46",
+				"@php-wasm/util": "3.1.46",
+				"@php-wasm/web-service-worker": "3.1.46",
+				"@wp-playground/common": "3.1.46",
+				"@wp-playground/storage": "3.1.46",
+				"@wp-playground/wordpress": "3.1.46",
+				"ajv": "8.18.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
@@ -9031,102 +8020,20 @@
 			}
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+			"version": "8.18.0",
+			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
+			"integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
+				"fast-deep-equal": "^3.1.3",
+				"fast-uri": "^3.0.1",
 				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
+				"require-from-string": "^2.0.2"
 			},
 			"funding": {
 				"type": "github",
 				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@wp-playground/blueprints/node_modules/json-schema-traverse": {
@@ -9136,838 +8043,97 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@wp-playground/blueprints/node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/playwright": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-			"integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"playwright-core": "1.55.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/playwright-core": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-			"integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wp-playground/blueprints/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wp-playground/cli": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.26.tgz",
-			"integrity": "sha512-D36l+U2zpz6mymx+i7GnfIV2XI0bKPqv1xXWc2wrXK4ES+GBUFkqm6oWfaemVAptDSYWmPp+hw3EIYn1/0Qtdw==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@wp-playground/cli/-/cli-3.1.46.tgz",
+			"integrity": "sha512-rn20w2Fp72wwnnOB+UyvvZ9zRx1dsPXC7KSMgJFEvoLNEVdp3bXcvyv8U5XZpeAPqkZB7nhMJDwOhcLR4SqVOA==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/cli-util": "3.1.26",
-				"@php-wasm/logger": "3.1.26",
-				"@php-wasm/node": "3.1.26",
-				"@php-wasm/progress": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"@php-wasm/util": "3.1.26",
-				"@php-wasm/xdebug-bridge": "3.1.26",
-				"@wp-playground/blueprints": "3.1.26",
-				"@wp-playground/common": "3.1.26",
-				"@wp-playground/storage": "3.1.26",
-				"@wp-playground/tools": "3.1.26",
-				"@wp-playground/wordpress": "3.1.26",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
+				"@php-wasm/cli-util": "3.1.46",
+				"@php-wasm/logger": "3.1.46",
+				"@php-wasm/node": "3.1.46",
+				"@php-wasm/progress": "3.1.46",
+				"@php-wasm/universal": "3.1.46",
+				"@php-wasm/util": "3.1.46",
+				"@php-wasm/xdebug-bridge": "3.1.46",
+				"@wp-playground/blueprints": "3.1.46",
+				"@wp-playground/common": "3.1.46",
+				"@wp-playground/storage": "3.1.46",
+				"@wp-playground/tools": "3.1.46",
+				"@wp-playground/wordpress": "3.1.46",
+				"express": "4.22.2",
 				"fs-extra": "11.1.1",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"playwright": "1.55.1",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
 				"tmp-promise": "3.0.3",
 				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0",
-				"xml2js": "0.6.2",
 				"yargs": "17.7.2"
 			},
 			"bin": {
 				"wp-playground-cli": "wp-playground.js"
 			}
 		},
-		"node_modules/@wp-playground/cli/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/cli/node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/cli/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/cli/node_modules/playwright": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-			"integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"playwright-core": "1.55.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/playwright-core": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-			"integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wp-playground/cli/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/@wp-playground/common": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.26.tgz",
-			"integrity": "sha512-ROa91YyI75xM5kxYULn4UYbjJ27JvLOxQ5bR1QV1y5PwcS+8J4Zaa/00hdkZJox98DQTzQ2ZT3Vb84j59h9TJQ==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@wp-playground/common/-/common-3.1.46.tgz",
+			"integrity": "sha512-MZ4ZSsh9GG7oHYhe38T+9uW6mGDvlwoH8IyJWNJN/PgH5SPPUHnP1CtmiMTl/p+sOf4ELf4A/REa16OtoJ83Qg==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/universal": "3.1.26",
-				"@php-wasm/util": "3.1.26",
-				"ajv": "8.12.0",
-				"ini": "4.1.2"
+				"@php-wasm/universal": "3.1.46",
+				"@php-wasm/util": "3.1.46"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
 			}
 		},
-		"node_modules/@wp-playground/common/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/common/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/common/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@wp-playground/storage": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.26.tgz",
-			"integrity": "sha512-K8F/OmEES8/hMNRfL4+e+OnbSnjAbEiGrbCZ2HWNxQdRkqSCsgf+UVnc1cY7hEWUZUFfE5pvbgCpknCo5aq75A==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@wp-playground/storage/-/storage-3.1.46.tgz",
+			"integrity": "sha512-NH9Tkt4WBpFtgZ6KrUkPJygsjzbbN1UVQ7IBawQba4dB2mjx2HNznUT3qyCPpQL6Vn8dO9YFHQ4fRLxvWbeCpw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/stream-compression": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"@php-wasm/util": "3.1.26",
+				"@php-wasm/stream-compression": "3.1.46",
+				"@php-wasm/universal": "3.1.46",
+				"@php-wasm/util": "3.1.46",
 				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "^1.4.1",
-				"clean-git-ref": "^2.0.1",
-				"crc-32": "^1.2.0",
-				"diff3": "0.0.3",
-				"ignore": "^5.1.4",
-				"ini": "4.1.2",
-				"minimisted": "^2.0.0",
+				"isomorphic-git": "1.37.6",
 				"octokit": "3.1.2",
 				"pako": "^1.0.10",
-				"pify": "^4.0.1",
-				"readable-stream": "^3.4.0",
-				"sha.js": "^2.4.9",
-				"simple-get": "^4.0.1"
-			}
-		},
-		"node_modules/@wp-playground/storage/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/storage/node_modules/diff3": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
-			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/storage/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/storage/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/storage/node_modules/pify": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=6"
+				"sha.js": "2.4.12"
 			}
 		},
 		"node_modules/@wp-playground/tools": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.26.tgz",
-			"integrity": "sha512-4dT/NvwegeD8PJG5/NNIkOpVgsmV2cg3Q1vmyEuDUowbvAuspl5oXSQptsnLK5iZZEc0OPK4J/47/EtxvapHVA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@wp-playground/tools/-/tools-3.1.46.tgz",
+			"integrity": "sha512-rSov51gL1HnxgXkhw2TO9EIuldj3aaBYPGQ+MQsmF5adV5CSYdw+wq2ZJS/wpUiePyv6gvdZJTWaVqbjINFc2w==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@wp-playground/blueprints": "3.1.26",
-				"@zip.js/zip.js": "2.7.57",
-				"ajv": "8.12.0",
-				"async-lock": "1.4.1",
-				"clean-git-ref": "2.0.1",
-				"crc-32": "1.2.2",
-				"diff3": "0.0.4",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ignore": "5.3.2",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"minimisted": "2.0.1",
-				"octokit": "3.1.2",
-				"pako": "1.0.10",
-				"pify": "2.3.0",
-				"playwright": "1.55.1",
-				"readable-stream": "3.6.2",
-				"sha.js": "2.4.12",
-				"simple-get": "4.0.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0",
-				"yargs": "17.7.2"
+				"@wp-playground/blueprints": "3.1.46"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/tools/node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/tools/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/tools/node_modules/playwright": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-			"integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"playwright-core": "1.55.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/playwright-core": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-			"integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wp-playground/tools/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@wp-playground/wordpress": {
-			"version": "3.1.26",
-			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.26.tgz",
-			"integrity": "sha512-an5UDOx4fnY83VrS53qf32RGXuNH2QrKgaQPq9jA0SZ5hwXyPcr34NmC16bHPFqWS64q59HvdyrwV3Ts4w6hmA==",
+			"version": "3.1.46",
+			"resolved": "https://registry.npmjs.org/@wp-playground/wordpress/-/wordpress-3.1.46.tgz",
+			"integrity": "sha512-QGzxrSmlm3ewiyU6NB2VDMgqZ5ZPuuSsPg4YkRnQrX489v0ohqCLp/jUe/+5nvXKGNg4KnR/37QrerEtLryXcw==",
 			"dev": true,
 			"license": "GPL-2.0-or-later",
 			"dependencies": {
-				"@php-wasm/logger": "3.1.26",
-				"@php-wasm/node": "3.1.26",
-				"@php-wasm/universal": "3.1.26",
-				"@php-wasm/util": "3.1.26",
-				"@wp-playground/common": "3.1.26",
-				"ajv": "8.12.0",
-				"express": "4.22.0",
-				"fast-xml-parser": "^5.5.1",
-				"fs-ext-extra-prebuilt": "2.2.7",
-				"ini": "4.1.2",
-				"jsonc-parser": "3.3.1",
-				"playwright": "1.55.1",
-				"wasm-feature-detect": "1.8.0",
-				"ws": "8.18.0",
-				"yargs": "17.7.2"
+				"@php-wasm/logger": "3.1.46",
+				"@php-wasm/universal": "3.1.46",
+				"@php-wasm/util": "3.1.46",
+				"@wp-playground/common": "3.1.46",
+				"zstddec": "^0.2.0"
 			},
 			"engines": {
 				"node": ">=20.10.0",
 				"npm": ">=10.2.3"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/ajv": {
-			"version": "8.12.0",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
-			"integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"fast-deep-equal": "^3.1.1",
-				"json-schema-traverse": "^1.0.0",
-				"require-from-string": "^2.0.2",
-				"uri-js": "^4.2.2"
-			},
-			"funding": {
-				"type": "github",
-				"url": "https://github.com/sponsors/epoberezkin"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/express": {
-			"version": "4.22.0",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.0.tgz",
-			"integrity": "sha512-c2iPh3xp5vvCLgaHK03+mWLFPhox7j1LwyxcZwFVApEv5i0X+IjPpbT50SJJwwLpdBVfp45AkK/v+AFgv/XlfQ==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"accepts": "~1.3.8",
-				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
-				"content-disposition": "~0.5.4",
-				"content-type": "~1.0.4",
-				"cookie": "~0.7.1",
-				"cookie-signature": "~1.0.6",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"encodeurl": "~2.0.0",
-				"escape-html": "~1.0.3",
-				"etag": "~1.8.1",
-				"finalhandler": "~1.3.1",
-				"fresh": "~0.5.2",
-				"http-errors": "~2.0.0",
-				"merge-descriptors": "1.0.3",
-				"methods": "~1.1.2",
-				"on-finished": "~2.4.1",
-				"parseurl": "~1.3.3",
-				"path-to-regexp": "~0.1.12",
-				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
-				"range-parser": "~1.2.1",
-				"safe-buffer": "5.2.1",
-				"send": "~0.19.0",
-				"serve-static": "~1.16.2",
-				"setprototypeof": "1.2.0",
-				"statuses": "~2.0.1",
-				"type-is": "~1.6.18",
-				"utils-merge": "1.0.1",
-				"vary": "~1.1.2"
-			},
-			"engines": {
-				"node": ">= 0.10.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/express"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/fsevents": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-			"integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-			"dev": true,
-			"hasInstallScript": true,
-			"license": "MIT",
-			"optional": true,
-			"os": [
-				"darwin"
-			],
-			"engines": {
-				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/ini": {
-			"version": "4.1.2",
-			"resolved": "https://registry.npmjs.org/ini/-/ini-4.1.2.tgz",
-			"integrity": "sha512-AMB1mvwR1pyBFY/nSevUX6y8nJWS63/SzUKD3JyQn97s4xgIdgQPT75IRouIiBAN4yLQBUShNYVW0+UG25daCw==",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/json-schema-traverse": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-			"integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/jsonc-parser": {
-			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
-			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/playwright": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright/-/playwright-1.55.1.tgz",
-			"integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"playwright-core": "1.55.1"
-			},
-			"bin": {
-				"playwright": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			},
-			"optionalDependencies": {
-				"fsevents": "2.3.2"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/playwright-core": {
-			"version": "1.55.1",
-			"resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.55.1.tgz",
-			"integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"bin": {
-				"playwright-core": "cli.js"
-			},
-			"engines": {
-				"node": ">=18"
-			}
-		},
-		"node_modules/@wp-playground/wordpress/node_modules/ws": {
-			"version": "8.18.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.18.0.tgz",
-			"integrity": "sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=10.0.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
 			}
 		},
 		"node_modules/@xtuc/ieee754": {
@@ -10003,6 +8169,19 @@
 			"deprecated": "Use your platform's native atob() and btoa() methods instead",
 			"dev": true,
 			"license": "BSD-3-Clause"
+		},
+		"node_modules/abort-controller": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+			"integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"event-target-shim": "^5.0.0"
+			},
+			"engines": {
+				"node": ">=6.5"
+			}
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -10099,9 +8278,9 @@
 			}
 		},
 		"node_modules/adm-zip": {
-			"version": "0.5.17",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.17.tgz",
-			"integrity": "sha512-+Ut8d9LLqwEvHHJl1+PIHqoyDxFgVN847JTVM3Izi3xHDWPE4UtzzXysMZQs64DMcrJfBeS/uoEP4AD3HQHnQQ==",
+			"version": "0.5.18",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.5.18.tgz",
+			"integrity": "sha512-ufJnssQGbxzLNS1Ho9bCtX4rQKCCvoVuDLHoJyc3F9dOGDB4BkWs2Ci0kv53lqocAEQ/Cbi+I2XCsNYGqVYqng==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -10318,6 +8497,19 @@
 			"engines": {
 				"node": ">= 8"
 			}
+		},
+		"node_modules/anynum": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/anynum/-/anynum-1.0.1.tgz",
+			"integrity": "sha512-N6//FLET/tXYNM/F6ABca1oH6fWB+KlTt909Le28WMDBk8oaT4vY17DCrwg2MvmuqUKt3Ni4N5dGJ/EoBgcO6A==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/are-docs-informative": {
 			"version": "0.0.2",
@@ -10675,14 +8867,15 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "1.15.0",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-			"integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+			"version": "1.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+			"integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.15.11",
+				"follow-redirects": "^1.16.0",
 				"form-data": "^4.0.5",
+				"https-proxy-agent": "^5.0.1",
 				"proxy-from-env": "^2.1.0"
 			}
 		},
@@ -10991,9 +9184,9 @@
 			"license": "MIT"
 		},
 		"node_modules/baseline-browser-mapping": {
-			"version": "2.10.20",
-			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.20.tgz",
-			"integrity": "sha512-1AaXxEPfXT+GvTBJFuy4yXVHWJBXa4OdbIebGN/wX5DlsIkU0+wzGnd2lOzokSk51d5LUmqjgBLRLlypLUqInQ==",
+			"version": "2.11.1",
+			"resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.1.tgz",
+			"integrity": "sha512-HYXq73DDpCtNzOmrFsm9eSwCvWCql0RzqjpDzXN9EadiLJ4DNat0nsZ/Bzmy+Ud12mb4/zKDY0cQ805ZzN+i0A==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"bin": {
@@ -11004,9 +9197,9 @@
 			}
 		},
 		"node_modules/basic-ftp": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.0.tgz",
-			"integrity": "sha512-5K9eNNn7ywHPsYnFwjKgYH8Hf8B5emh7JKcPaVjjrMJFQQwGpwowEnZNEtHs7DfR7hCZsmaK3VA4HUK0YarT+w==",
+			"version": "5.3.1",
+			"resolved": "https://registry.npmjs.org/basic-ftp/-/basic-ftp-5.3.1.tgz",
+			"integrity": "sha512-bopVNp6ugyA150DDuZfPFdt1KZ5a94ZDiwX4hMgZDzF+GttD80lEy8kj98kbyhLXnPvhtIo93mdnLIjpCAeeOw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -11051,9 +9244,9 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.4",
-			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
-			"integrity": "sha512-ZTgYYLMOXY9qKU/57FAo8F+HA2dGX7bqGc71txDRC1rS4frdFI5R7NhluHxH6M0YItAP0sHB4uqAOcYKxO6uGA==",
+			"version": "1.20.6",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.6.tgz",
+			"integrity": "sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11065,7 +9258,7 @@
 				"http-errors": "~2.0.1",
 				"iconv-lite": "~0.4.24",
 				"on-finished": "~2.4.1",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"raw-body": "~2.5.3",
 				"type-is": "~1.6.18",
 				"unpipe": "~1.0.0"
@@ -11131,9 +9324,9 @@
 			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
-			"integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.2.tgz",
+			"integrity": "sha512-w5JZcKgdhDOgOwm8H+KgbosopHMuGcl6qbulwjtz3SM7I7P3yW1eAjzMPLrIE+NQ9vjgANKHWeMHnrT0OXW1oA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -11154,9 +9347,9 @@
 			}
 		},
 		"node_modules/browserslist": {
-			"version": "4.28.2",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.2.tgz",
-			"integrity": "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==",
+			"version": "4.28.7",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.7.tgz",
+			"integrity": "sha512-JxV13hNrFxqjOc8alRbq9dK1MM79NEXYpma2B2J4wAtpWS5zIEIKqWPGCl7N4o7Uc7B7itylh7SuDujATRyyTw==",
 			"dev": true,
 			"funding": [
 				{
@@ -11174,10 +9367,10 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"baseline-browser-mapping": "^2.10.12",
-				"caniuse-lite": "^1.0.30001782",
-				"electron-to-chromium": "^1.5.328",
-				"node-releases": "^2.0.36",
+				"baseline-browser-mapping": "^2.10.44",
+				"caniuse-lite": "^1.0.30001806",
+				"electron-to-chromium": "^1.5.393",
+				"node-releases": "^2.0.51",
 				"update-browserslist-db": "^1.2.3"
 			},
 			"bin": {
@@ -11471,9 +9664,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001788",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001788.tgz",
-			"integrity": "sha512-6q8HFp+lOQtcf7wBK+uEenxymVWkGKkjFpCvw5W25cmMwEDU45p1xQFBQv8JDlMMry7eNxyBaR+qxgmTUZkIRQ==",
+			"version": "1.0.30001806",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001806.tgz",
+			"integrity": "sha512-72Cuvd95zbSYPKq6Fhg8eDJRlzgWDf7/mtoZv6Qe/DYNCEBdNxoA3+rZAU2ZhGCpZlns3EssFavaZomckT5Uuw==",
 			"dev": true,
 			"funding": [
 				{
@@ -12258,10 +10451,20 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/cosmiconfig/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -13045,9 +11248,9 @@
 			}
 		},
 		"node_modules/diff3": {
-			"version": "0.0.4",
-			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.4.tgz",
-			"integrity": "sha512-f1rQ7jXDn/3i37hdwRk9ohqcvLRH3+gEIgmA6qEM280WUOh7cOr3GXV8Jm5sPwUs46Nzl48SE8YNLGJoaLuodg==",
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/diff3/-/diff3-0.0.3.tgz",
+			"integrity": "sha512-iSq8ngPOt0K53A6eVr4d5Kn6GNrM2nQZtC740pzIriHtn4pOQ2lyzEXQMBeVcWERN0ye7fhBsk9PbLLQOnUx/g==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -13279,9 +11482,9 @@
 			"license": "MIT"
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.340",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.340.tgz",
-			"integrity": "sha512-908qahOGocRMinT2nM3ajCEM99H4iPdv84eagPP3FfZy/1ZGeOy2CZYzjhms81ckOPCXPlW7LkY4XpxD8r1DrA==",
+			"version": "1.5.396",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.396.tgz",
+			"integrity": "sha512-yHiw2Y3C3H9U6TMbOfoWK/BPreiOPXRfTWPBwQBoZG6/8TB6eOPnsy5oaRYuatR7Fw2SJ4kKforgufeo7fq0EQ==",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -13905,9 +12108,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-import/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14176,9 +12379,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-jsx-a11y/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14293,9 +12496,9 @@
 			}
 		},
 		"node_modules/eslint-plugin-react/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14395,9 +12598,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/eslint/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14453,10 +12656,20 @@
 			}
 		},
 		"node_modules/eslint/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -14611,6 +12824,16 @@
 				"node": ">= 0.6"
 			}
 		},
+		"node_modules/event-target-shim": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+			"integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/eventemitter3": {
 			"version": "4.0.7",
 			"resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
@@ -14709,15 +12932,15 @@
 			"license": "MIT"
 		},
 		"node_modules/express": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
-			"integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/express/-/express-4.22.2.tgz",
+			"integrity": "sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"accepts": "~1.3.8",
 				"array-flatten": "1.1.1",
-				"body-parser": "~1.20.3",
+				"body-parser": "~1.20.5",
 				"content-disposition": "~0.5.4",
 				"content-type": "~1.0.4",
 				"cookie": "~0.7.1",
@@ -14736,7 +12959,7 @@
 				"parseurl": "~1.3.3",
 				"path-to-regexp": "~0.1.12",
 				"proxy-addr": "~2.0.7",
-				"qs": "~6.14.0",
+				"qs": "~6.15.1",
 				"range-parser": "~1.2.1",
 				"safe-buffer": "5.2.1",
 				"send": "~0.19.0",
@@ -14875,9 +13098,9 @@
 			"license": "MIT"
 		},
 		"node_modules/fast-uri": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-			"integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+			"integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
 			"dev": true,
 			"funding": [
 				{
@@ -14892,9 +13115,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-builder": {
-			"version": "1.1.6",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.6.tgz",
-			"integrity": "sha512-exq7uOuwxoIsWZ7wKf9CV4Q0/yEAHxtktYDjCGsGrg+uKnNY/ly04Wkb2npZo5GEwz963yu+PRp+HLJf/qRrpQ==",
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.3.0.tgz",
+			"integrity": "sha512-F74cZEdCvuw9P41GAC3rod4X04jjWGM1JPEv/GWSqFTWLsdyMSBMBMlm9Hk3GLBgLBbdBNY8yee0pQh2RBVESQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -14904,13 +13127,14 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"path-expression-matcher": "^1.1.3"
+				"path-expression-matcher": "^1.6.2",
+				"xml-naming": "^0.3.0"
 			}
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "5.7.2",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.2.tgz",
-			"integrity": "sha512-P7oW7tLbYnhOLQk/Gv7cZgzgMPP/XN03K02/Jy6Y/NHzyIAIpxuZIM/YqAkfiXFPxA2CTm7NtCijK9EDu09u2w==",
+			"version": "5.10.1",
+			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.10.1.tgz",
+			"integrity": "sha512-IEMIf7298kXuZSRFoGfMYrl7is8LpavODgbNz1cwIudv7KwVFnuU+UsMporfq6PD6aXSlawZlARiA3UywCTfMw==",
 			"dev": true,
 			"funding": [
 				{
@@ -14920,10 +13144,12 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"@nodable/entities": "^2.1.0",
-				"fast-xml-builder": "^1.1.5",
-				"path-expression-matcher": "^1.5.0",
-				"strnum": "^2.2.3"
+				"@nodable/entities": "^3.0.0",
+				"fast-xml-builder": "^1.2.0",
+				"is-unsafe": "^2.0.0",
+				"path-expression-matcher": "^1.6.2",
+				"strnum": "^2.4.1",
+				"xml-naming": "^0.3.0"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -15275,17 +13501,17 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.5",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
-			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"version": "4.0.6",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.2",
-				"mime-types": "^2.1.12"
+				"hasown": "^2.0.4",
+				"mime-types": "^2.1.35"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -15658,9 +13884,9 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/glob/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -15966,9 +14192,9 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.3",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
-			"integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16228,9 +14454,9 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "2.0.9",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.9.tgz",
-			"integrity": "sha512-c1IyJYLYppU574+YI7R4QyX2ystMtVXZwIdzazUIPIJsHuWNd+mho2j+bKoHftndicGj9yh+xjd+l0yj7VeT1Q==",
+			"version": "2.0.10",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-2.0.10.tgz",
+			"integrity": "sha512-RKzRWNPxUZqbuk3BC5mGVJbBnWgr+diEnjJexIOytFbBzDy88Fbh/YvBr3DsNrl1jYAfjWfpATEv0NO35FDuPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16374,9 +14600,9 @@
 			}
 		},
 		"node_modules/ignore-walk/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -16405,9 +14631,9 @@
 			"license": "MIT"
 		},
 		"node_modules/immutable": {
-			"version": "5.1.5",
-			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.5.tgz",
-			"integrity": "sha512-t7xcm2siw+hlUM68I+UEOK+z84RzmN59as9DZ7P1l0994DKUWV7UXBMQZVxaoMSRQ+PBZbHCOoBt7a2wxOMt+A==",
+			"version": "5.1.9",
+			"resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+			"integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -16569,9 +14795,9 @@
 			}
 		},
 		"node_modules/ip-address": {
-			"version": "10.1.0",
-			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-			"integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+			"version": "10.3.0",
+			"resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.3.0.tgz",
+			"integrity": "sha512-WjqUcdgafPtBplAfDpvR1ZWncdjC2q0P1PHmCkh4edxwiANBDhuDx26cKD7HIl6UGd6BSjwnPVt58X0r5Z85eQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -17132,6 +15358,19 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/is-unsafe": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/is-unsafe/-/is-unsafe-2.0.0.tgz",
+			"integrity": "sha512-2LdV822R+wmI86unXA93WCFpL6g+av8ynWk0nrHyJqGop5VoocYsSLFgN8jrfalT6iGeLNM4KXuVSsULP53kEA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/is-weakmap": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/is-weakmap/-/is-weakmap-2.0.2.tgz",
@@ -17223,6 +15462,84 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/isomorphic-git": {
+			"version": "1.37.6",
+			"resolved": "https://registry.npmjs.org/isomorphic-git/-/isomorphic-git-1.37.6.tgz",
+			"integrity": "sha512-qr1NFCPsVTZ6YGqTXw0CzamnsHyH9QQ1OTEfeXIweSljRUMzuHFCJdUn0wc6OcjtTDns6knxjPb7N6LmJeftOA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"async-lock": "^1.4.1",
+				"clean-git-ref": "^2.0.1",
+				"crc-32": "^1.2.0",
+				"diff3": "0.0.3",
+				"ignore": "^5.1.4",
+				"minimisted": "^2.0.0",
+				"pako": "^1.0.10",
+				"pify": "^4.0.1",
+				"readable-stream": "^4.0.0",
+				"sha.js": "^2.4.12",
+				"simple-get": "^4.0.1"
+			},
+			"bin": {
+				"isogit": "cli.cjs"
+			},
+			"engines": {
+				"node": ">=14.17"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/buffer": {
+			"version": "6.0.3",
+			"resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+			"integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/feross"
+				},
+				{
+					"type": "patreon",
+					"url": "https://www.patreon.com/feross"
+				},
+				{
+					"type": "consulting",
+					"url": "https://feross.org/support"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"base64-js": "^1.3.1",
+				"ieee754": "^1.2.1"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/pify": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+			"integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/isomorphic-git/node_modules/readable-stream": {
+			"version": "4.7.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-4.7.0.tgz",
+			"integrity": "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"abort-controller": "^3.0.0",
+				"buffer": "^6.0.3",
+				"events": "^3.3.0",
+				"process": "^0.11.10",
+				"string_decoder": "^1.3.0"
+			},
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
 			}
 		},
 		"node_modules/istanbul-lib-coverage": {
@@ -17971,9 +16288,9 @@
 			}
 		},
 		"node_modules/joi": {
-			"version": "18.1.2",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.1.2.tgz",
-			"integrity": "sha512-rF5MAmps5esSlhCA+N1b6IYHDw9j/btzGaqfgie522jS02Ju/HXBxamlXVlKEHAxoMKQL77HWI8jlqWsFuekZA==",
+			"version": "18.2.3",
+			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.3.tgz",
+			"integrity": "sha512-N5A3KTWQpPWT4ExxxPlUx7WmykGXRzhNidWhV41d6Abu9YfI2NyWCJuxdPnslJCPWtbRpSVOWSnSS6GakLM/Rg==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -18014,9 +16331,9 @@
 			"license": "MIT"
 		},
 		"node_modules/js-yaml": {
-			"version": "3.14.2",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
-			"integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+			"version": "3.15.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
+			"integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18198,9 +16515,9 @@
 			}
 		},
 		"node_modules/jsonwebtoken/node_modules/semver": {
-			"version": "7.7.4",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-			"integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+			"version": "7.8.5",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+			"integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
 			"dev": true,
 			"license": "ISC",
 			"bin": {
@@ -18320,14 +16637,14 @@
 			}
 		},
 		"node_modules/launch-editor": {
-			"version": "2.13.2",
-			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.13.2.tgz",
-			"integrity": "sha512-4VVDnbOpLXy/s8rdRCSXb+zfMeFR0WlJWpET1iA9CQdlZDfwyLjUuGQzXU4VeOoey6AicSAluWan7Etga6Kcmg==",
+			"version": "2.14.1",
+			"resolved": "https://registry.npmjs.org/launch-editor/-/launch-editor-2.14.1.tgz",
+			"integrity": "sha512-QWBrQsMpH7gPr965dsKD/3cKWiNoTjpATQf++Xq63N6sKRGMwlVXz41O1IZTMfZQgBctD/K5Zt06+/I6pP6+HA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"picocolors": "^1.1.1",
-				"shell-quote": "^1.8.3"
+				"shell-quote": "^1.8.4"
 			}
 		},
 		"node_modules/lazy-cache": {
@@ -18496,9 +16813,9 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/lighthouse/node_modules/puppeteer-core/node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.1",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
+			"integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -18531,9 +16848,9 @@
 			}
 		},
 		"node_modules/lighthouse/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -18952,9 +17269,9 @@
 			"license": "Python-2.0"
 		},
 		"node_modules/markdownlint-cli/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -18983,10 +17300,20 @@
 			}
 		},
 		"node_modules/markdownlint-cli/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -19478,16 +17805,16 @@
 			}
 		},
 		"node_modules/nan": {
-			"version": "2.26.2",
-			"resolved": "https://registry.npmjs.org/nan/-/nan-2.26.2.tgz",
-			"integrity": "sha512-0tTvBTYkt3tdGw22nrAy50x7gpbGCCFH3AFcyS5WiUu7Eu4vWlri1woE6qHBSfy11vksDqkiwjOnlR7WV8G1Hw==",
+			"version": "2.28.0",
+			"resolved": "https://registry.npmjs.org/nan/-/nan-2.28.0.tgz",
+			"integrity": "sha512-fTsDz99OTq2sVePhGdp4qQhggZFtKr64ZNVyVajRKtMOkJxYekplBh577PiJB12v/D3s2E5cGtOI45LWp6rnLQ==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/nanoid": {
-			"version": "3.3.11",
-			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-			"integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+			"version": "3.3.16",
+			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+			"integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
 			"dev": true,
 			"funding": [
 				{
@@ -19609,11 +17936,14 @@
 			"license": "MIT"
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.37",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.37.tgz",
-			"integrity": "sha512-1h5gKZCF+pO/o3Iqt5Jp7wc9rH3eJJ0+nh/CIoiRwjRxde/hAHyLPXYN4V3CqKAbiZPSeJFSWHmJsbkicta0Eg==",
+			"version": "2.0.51",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.51.tgz",
+			"integrity": "sha512-wRNIrw4DmVLKQlbgOMdkMx27Wrpzes2hh5Jtbi2bjPd+4wJstWIqP5A+lscnqbm0xxmT5Bpg8Lec5ItEBwx6BQ==",
 			"dev": true,
-			"license": "MIT"
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			}
 		},
 		"node_modules/normalize-package-data": {
 			"version": "3.0.3",
@@ -20378,9 +18708,9 @@
 			"license": "BlueOak-1.0.0"
 		},
 		"node_modules/pako": {
-			"version": "1.0.10",
-			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
-			"integrity": "sha512-0DTvPVU3ed8+HNXOu5Bs+o//Mbdj9VNQMUOe9oKCwh8l0GNwpTDMKCWbRjgtD291AWnkAgkqA/LOnQS8AmS1tw==",
+			"version": "1.0.11",
+			"resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
+			"integrity": "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw==",
 			"dev": true,
 			"license": "(MIT AND Zlib)"
 		},
@@ -20512,9 +18842,9 @@
 			}
 		},
 		"node_modules/path-expression-matcher": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-			"integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+			"version": "1.6.2",
+			"resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.2.tgz",
+			"integrity": "sha512-enSlaiat05iasnzmgNxRj8reFdj3puY2QpNgP1aPIaVfT6nn9ICuPoFlKHk8EN22HcwewshO+mN2DGbkCEOtqQ==",
 			"dev": true,
 			"funding": [
 				{
@@ -20854,9 +19184,9 @@
 			}
 		},
 		"node_modules/postcss": {
-			"version": "8.5.10",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
-			"integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+			"version": "8.5.23",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+			"integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
 			"dev": true,
 			"funding": [
 				{
@@ -20874,7 +19204,7 @@
 			],
 			"license": "MIT",
 			"dependencies": {
-				"nanoid": "^3.3.11",
+				"nanoid": "^3.3.16",
 				"picocolors": "^1.1.1",
 				"source-map-js": "^1.2.1"
 			},
@@ -21678,6 +20008,16 @@
 				"url": "https://github.com/chalk/ansi-styles?sponsor=1"
 			}
 		},
+		"node_modules/process": {
+			"version": "0.11.10",
+			"resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+			"integrity": "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6.0"
+			}
+		},
 		"node_modules/process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -21924,13 +20264,14 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.14.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.14.2.tgz",
-			"integrity": "sha512-V/yCWTTF7VJ9hIh18Ugr2zhJMP01MY7c5kh4J870L7imm6/DIzBsNLTXzMwUA3yZ5b/KBqLx8Kp3uRvd7xSe3Q==",
+			"version": "6.15.3",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+			"integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.1.0"
+				"es-define-property": "^1.0.1",
+				"side-channel": "^1.1.1"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -23200,9 +21541,9 @@
 			}
 		},
 		"node_modules/shell-quote": {
-			"version": "1.8.3",
-			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
-			"integrity": "sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==",
+			"version": "1.10.0",
+			"resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.10.0.tgz",
+			"integrity": "sha512-w1aiOKwKuRgtwAReIIj89puqg+I7GvX4IbLrvmhXbzQsj1+Zwi4VO3+fa6ZF91TWSjIxoEkKnMeHcLEODK5ZXA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -23220,15 +21561,15 @@
 			"license": "BSD-2-Clause"
 		},
 		"node_modules/side-channel": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-			"integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+			"integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-errors": "^1.3.0",
-				"object-inspect": "^1.13.3",
-				"side-channel-list": "^1.0.0",
+				"object-inspect": "^1.13.4",
+				"side-channel-list": "^1.0.1",
 				"side-channel-map": "^1.0.1",
 				"side-channel-weakmap": "^1.0.2"
 			},
@@ -24037,9 +22378,9 @@
 			}
 		},
 		"node_modules/strnum": {
-			"version": "2.2.3",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
-			"integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
+			"version": "2.4.1",
+			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.4.1.tgz",
+			"integrity": "sha512-M9eUSMT2dCB2cTNPG7UYj6KuK7RJR2SN2+yCV/fTW3xzTCS6EaGZ5pSMgDIjB7r8zSfTGk+dvvn9rTjpVS9Mwg==",
 			"dev": true,
 			"funding": [
 				{
@@ -24047,7 +22388,10 @@
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
-			"license": "MIT"
+			"license": "MIT",
+			"dependencies": {
+				"anynum": "^1.0.1"
+			}
 		},
 		"node_modules/stubborn-fs": {
 			"version": "2.0.0",
@@ -24387,10 +22731,20 @@
 			}
 		},
 		"node_modules/stylelint/node_modules/js-yaml": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-			"integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
+			"integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
 			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/nodeca"
+				}
+			],
 			"license": "MIT",
 			"dependencies": {
 				"argparse": "^2.0.1"
@@ -24533,9 +22887,9 @@
 			"dev": true
 		},
 		"node_modules/svgo": {
-			"version": "3.3.3",
-			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.3.tgz",
-			"integrity": "sha512-+wn7I4p7YgJhHs38k2TNjy1vCfPIfLIJWR5MnCStsN8WuuTcBnRKcMHQLMM2ijxGZmDoZwNv8ipl5aTTen62ng==",
+			"version": "3.3.4",
+			"resolved": "https://registry.npmjs.org/svgo/-/svgo-3.3.4.tgz",
+			"integrity": "sha512-GsNRis4e8jxn2Y9ENz/8lbJ93CstG8svtMnuRaHbiF2LTJ5tK0/q3t/URPq9Zc7zVWBJnNnJMIp6bevK7bSmNg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -24879,9 +23233,9 @@
 			}
 		},
 		"node_modules/test-exclude/node_modules/brace-expansion": {
-			"version": "1.1.14",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.14.tgz",
-			"integrity": "sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==",
+			"version": "1.1.16",
+			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.16.tgz",
+			"integrity": "sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -25021,9 +23375,9 @@
 			}
 		},
 		"node_modules/tmp": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+			"version": "0.2.7",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+			"integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -25961,9 +24315,9 @@
 			}
 		},
 		"node_modules/webpack-bundle-analyzer/node_modules/ws": {
-			"version": "7.5.10",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
-			"integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+			"version": "7.5.13",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.13.tgz",
+			"integrity": "sha512-rsKI6xDBFVf4r/x8XyChGK04QR/XHroxs/jUcoWvtEZM8TPU/X/uIY9B1CsSzYws9ZJb/6bbBu7dPhFW00CAoA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -26257,9 +24611,9 @@
 			}
 		},
 		"node_modules/websocket-driver": {
-			"version": "0.7.4",
-			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-			"integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+			"integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -26507,9 +24861,9 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
-			"integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+			"version": "8.21.0",
+			"resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+			"integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -26549,6 +24903,22 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/xml-naming": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.3.0.tgz",
+			"integrity": "sha512-ghig2TBE/H11aOVgmahA3MhimvkBr6JIYknH/Dhdk10nXwdbIqBJsbfMxpvFPG8bAw77gN29aQWvKpmVoPlvPQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=16.0.0"
 			}
 		},
 		"node_modules/xml2js": {
@@ -26694,6 +25064,13 @@
 			"funding": {
 				"url": "https://github.com/sponsors/colinhacks"
 			}
+		},
+		"node_modules/zstddec": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/zstddec/-/zstddec-0.2.0.tgz",
+			"integrity": "sha512-oyPnDa1X5c13+Y7mA/FDMNJrn4S8UNBe0KCqtDmor40Re7ALrPN6npFwyYVRRh+PqozZQdeg23QtbcamZnG5rA==",
+			"dev": true,
+			"license": "MIT AND BSD-3-Clause"
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes #33 — a failed EMV 3DS2 **challenge** authentication (ACS redirect) left the customer with no visible error on **Block Checkout**, even though the order was correctly cancelled server-side.
- Root cause: the challenge-failure handler (`paygent_3ds2_redirect_order()`) runs on a plain page load (the ACS redirect back to order-pay), not during a Store API request. Block Checkout only surfaces `wc_add_notice()` calls raised *during* its own Store API request/response cycle (see `NoticeHandler::convert_notices_to_exceptions()` in WooCommerce core) — a notice added on a later, unrelated page load is simply discarded.
- Fix: the redirect back to checkout now also carries the failure reason — as a whitelisted opaque code, not free text (see Update below) — via a `paygent_3ds2_error` query arg. A small script enqueued on the checkout page dispatches the matching message into the `core/notices` store (`context: 'wc/checkout'`) — the same notice area the checkout block itself uses — so the error appears in the expected place and style. `wc_add_notice()` is kept as-is for classic/shortcode checkout compatibility.
- `class-wc-gateway-paygent-mccc.php`'s 4 duplicate call sites now reuse the same helper via its existing `$this->paygent_cc` delegation, rather than duplicating the logic.

**Update (94160af)**: addressed a Codex review finding that the original query-arg value was unsanitized free text, letting a crafted checkout link display fabricated payment/support messages inside the site's own error banner. The redirect now carries one of a small whitelisted code (`auth_failed`, `attempt_unknown`, `no_3ds_card`) instead, resolved server-side via `WC_Gateway_Paygent::get_3ds2_failure_messages()` — an unrecognized code renders nothing.

## Test plan
- [x] `composer test:unit` — 178/178 pass
- [x] `composer test:integration:wp-env` — 85/85 pass
- [x] `phpcs` — clean on all touched files
- [x] Reproduced the original bug live against a Paygent sandbox (real EMV 3DS2 challenge flow via the ACS simulator) on a Block-Checkout site, confirming no error was shown before this change
- [x] Re-verified end-to-end against that same live sandbox after deploying the fix — a real 3DS2 challenge failure now shows the expected error notice, and the order is still cancelled correctly server-side (see PR comments for details)
- [x] Classic (shortcode) checkout re-checked in a real browser — the notice is dispatched into the store but nothing renders (no listening UI there), no console errors, no duplicate display
- [x] Confirmed a non-whitelisted `paygent_3ds2_error` value now renders nothing at all (no script even enqueued), verifying the security fix from the second Codex pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
