### PR TITLE
fix: exclude development files from the distributed plugin

### DIFF
--- a/.distignore
+++ b/.distignore
@@ -10,6 +10,13 @@
 /.claude
 /script
 /report
+/2025docs
+/docs
+/tests
+/scripts
+/playwright-report
+/test-results
+/.playwright-mcp
 
 # Compiled translation files: local development only.
 # WordPress.org language packs (translate.wordpress.org) serve production
@@ -28,3 +35,13 @@ package-lock.json
 package.json
 README.md
 LICENSE
+AGENTS.md
+CLAUDE.md
+e2e.config.md
+phpcs.xml.dist
+phpunit.xml.dist
+phpunit-integration.xml.dist
+phpunit-sandbox.xml.dist
+playwright.config.js
+webpack.config.js
+wp-tests-config.php


### PR DESCRIPTION
The 3.0.0 deploy shipped 2025docs/ (Paygent specification PDFs), tests/, docs/, CI configs, and agent instruction files to WordPress.org SVN because .distignore was missing entries for directories added since 2.4.8. This adds all of them so future deploys only ship runtime files.

The already-deployed SVN trunk and tags/3.0.0 are being cleaned up separately via direct svn delete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)